### PR TITLE
Webgl perf

### DIFF
--- a/src/private/eegeo_map_controller.js
+++ b/src/private/eegeo_map_controller.js
@@ -59,9 +59,12 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
         trafficEnabled: true,
         trafficDisableWhenEnteringIndoorMaps: true,
         indoorLabelsAlwaysHidden: false,
-        framerateThrottlingEnables: false,
-        timeInMillisecondsBeforeReducingFramerate: 30000,
-        reducedFramerateIntervalSeconds: 1.0,
+
+        targetVSyncInterval: 1,
+        frameRateThrottleWhenIdleEnabled: false,
+        throttledTargetFrameIntervalMilliseconds: 1000,
+        idleSecondsBeforeFrameRateThrottle: 30.0,
+
         drawClearColor: "#000000ff",
         indoorMapBackgroundColor: "#000000c0"
     };
@@ -95,17 +98,12 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
     var _versionModule = new VersionModule(emscriptenApi);
     var _heatmapModule = new HeatmapModule(emscriptenApi);
 
-    var targetVSyncInterval = 1;
-    var throttledTargetFrameIntervalMilliseconds = options.reducedFramerateIntervalSeconds*1000;
-    var idleSecondsBeforeFrameRateThrottle = options.timeInMillisecondsBeforeReducingFramerate/1000;
-    var frameRateThrottleWhenIdleEnabled = options.framerateThrottlingEnables;
-
     var _frameRateModule = new FrameRateModule(
         emscriptenApi,
-        targetVSyncInterval,
-        throttledTargetFrameIntervalMilliseconds,
-        idleSecondsBeforeFrameRateThrottle,
-        frameRateThrottleWhenIdleEnabled
+        options.targetVSyncInterval,
+        options.throttledTargetFrameIntervalMilliseconds,
+        options.idleSecondsBeforeFrameRateThrottle,
+        options.frameRateThrottleWhenIdleEnabled
     );
 
     var _canvasId = _mapId ? options["canvasId"] + _mapId : options["canvasId"];
@@ -131,10 +129,6 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
     var trafficEnabled = (options.trafficEnabled) ? "1" : "0";
     var trafficDisableWhenEnteringIndoorMaps = (options.trafficDisableWhenEnteringIndoorMaps) ? "1" : "0";
     var indoorLabelsAlwaysHidden = (options.indoorLabelsAlwaysHidden) ? "1" : "0";
-    var framerateThrottlingEnabled = (options.framerateThrottlingEnables) ? "1" : "0";
-
-    var timeInMillisecondsBeforeReducingFramerate = options.timeInMillisecondsBeforeReducingFramerate;
-    var reducedFramerateIntervalSeconds = options.reducedFramerateIntervalSeconds;
 
     _Module["arguments"] = [
         _canvasId,
@@ -153,10 +147,7 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
         _containerId,
         trafficEnabled,
         trafficDisableWhenEnteringIndoorMaps,
-        indoorLabelsAlwaysHidden,
-        framerateThrottlingEnabled,
-        timeInMillisecondsBeforeReducingFramerate.toString(),
-        reducedFramerateIntervalSeconds.toString()
+        indoorLabelsAlwaysHidden
     ];
 
     this.leafletMap = new EegeoLeafletMap(

--- a/src/private/eegeo_map_controller.js
+++ b/src/private/eegeo_map_controller.js
@@ -15,6 +15,7 @@ var MapRuntimeModule = require("./map_runtime_module");
 var LayerPointMappingModule = require("./layer_point_mapping_module");
 var VersionModule = require("./version_module");
 var HeatmapModule = require("./heatmap_module");
+var FrameRateModule = require("./frame_rate_module");
 
 var IndoorEntranceMarkerUpdater = require("./indoor_entrance_marker_updater");
 
@@ -94,6 +95,19 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
     var _versionModule = new VersionModule(emscriptenApi);
     var _heatmapModule = new HeatmapModule(emscriptenApi);
 
+    var targetVSyncInterval = 1;
+    var throttledTargetFrameIntervalMilliseconds = options.reducedFramerateIntervalSeconds*1000;
+    var idleSecondsBeforeFrameRateThrottle = options.timeInMillisecondsBeforeReducingFramerate/1000;
+    var frameRateThrottleWhenIdleEnabled = options.framerateThrottlingEnables;
+
+    var _frameRateModule = new FrameRateModule(
+        emscriptenApi,
+        targetVSyncInterval,
+        throttledTargetFrameIntervalMilliseconds,
+        idleSecondsBeforeFrameRateThrottle,
+        frameRateThrottleWhenIdleEnabled
+    );
+
     var _canvasId = _mapId ? options["canvasId"] + _mapId : options["canvasId"];
     var _canvasWidth = options["width"] || domElement.clientWidth;
     var _canvasHeight = options["height"] || domElement.clientHeight;
@@ -117,7 +131,7 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
     var trafficEnabled = (options.trafficEnabled) ? "1" : "0";
     var trafficDisableWhenEnteringIndoorMaps = (options.trafficDisableWhenEnteringIndoorMaps) ? "1" : "0";
     var indoorLabelsAlwaysHidden = (options.indoorLabelsAlwaysHidden) ? "1" : "0";
-    var framerateThrottlingEnables = (options.framerateThrottlingEnables) ? "1" : "0";
+    var framerateThrottlingEnabled = (options.framerateThrottlingEnables) ? "1" : "0";
 
     var timeInMillisecondsBeforeReducingFramerate = options.timeInMillisecondsBeforeReducingFramerate;
     var reducedFramerateIntervalSeconds = options.reducedFramerateIntervalSeconds;
@@ -140,7 +154,7 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
         trafficEnabled,
         trafficDisableWhenEnteringIndoorMaps,
         indoorLabelsAlwaysHidden,
-        framerateThrottlingEnables,
+        framerateThrottlingEnabled,
         timeInMillisecondsBeforeReducingFramerate.toString(),
         reducedFramerateIntervalSeconds.toString()
     ];
@@ -164,7 +178,8 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
         _blueSphereModule,
         _mapRuntimeModule,
         _versionModule,
-        _heatmapModule
+        _heatmapModule,
+        _frameRateModule
     );
 
     this.leafletMap._initEvents(false, _canvas);
@@ -186,7 +201,8 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
         _blueSphereModule,
         _mapRuntimeModule,
         _versionModule,
-        _heatmapModule
+        _heatmapModule,
+        _frameRateModule
     ];
 
     this._indoorEntranceMarkerUpdater = null;

--- a/src/private/emscripten_api/emscripten_api.js
+++ b/src/private/emscripten_api/emscripten_api.js
@@ -17,6 +17,7 @@ var EmscriptenBlueSphereApi = require("./emscripten_blue_sphere_api.js");
 var EmscriptenMapRuntimeApi = require("./emscripten_map_runtime_api.js");
 var EmscriptenVersionApi = require("./emscripten_version_api.js");
 var EmscriptenHeatmapApi = require("./emscripten_heatmap_api.js");
+var EmscriptenFrameRateApi = require("./emscripten_frame_rate_api.js");
 
 function EmscriptenApi(emscriptenModule) {
 
@@ -43,6 +44,7 @@ function EmscriptenApi(emscriptenModule) {
     this.mapRuntimeApi = null;
     this.versionApi = null;
     this.heatmapApi = null;
+    this.frameRateApi = null;
 
     this.onInitialized = function(eegeoApiPointer, emscriptenApiPointer, onUpdateCallback, onDrawCallback, onInitialStreamingCompletedCallback) {
         _eegeoApiPointer = eegeoApiPointer;
@@ -75,6 +77,7 @@ function EmscriptenApi(emscriptenModule) {
         this.versionApi = new EmscriptenVersionApi(_emscriptenApiPointer, cwrap, emscriptenMemory);
         this.heatmapApi = new EmscriptenHeatmapApi(_emscriptenApiPointer, cwrap, runtime, emscriptenMemory);
         this.renderingApi = new EmscriptenRenderingApi(_emscriptenApiPointer, cwrap, runtime, emscriptenMemory);
+        this.frameRateApi = new EmscriptenFrameRateApi(_emscriptenApiPointer, cwrap, runtime, emscriptenMemory);
 
         var _setTopLevelCallbacks = _emscriptenModule.cwrap("setTopLevelCallbacks", null, ["number", "number", "number", "number"]);
         _setTopLevelCallbacks(

--- a/src/private/emscripten_api/emscripten_frame_rate_api.js
+++ b/src/private/emscripten_api/emscripten_frame_rate_api.js
@@ -1,10 +1,6 @@
-var space = require("../../public/space");
-var interopUtils = require("./emscripten_interop_utils.js");
-
 function EmscriptenFrameRateApi(emscriptenApiPointer, cwrap, runtime, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
-    var _emscriptenMemory = emscriptenMemory;
 
     var _frameRateApi_SetTargetVSyncInterval = cwrap("frameRateApi_SetTargetVSyncInterval", null, ["number", "number"]);
     var _frameRateApi_SetThrottledTargetFrameInterval = cwrap("frameRateApi_SetThrottledTargetFrameInterval", null, ["number", "number"]);

--- a/src/private/emscripten_api/emscripten_frame_rate_api.js
+++ b/src/private/emscripten_api/emscripten_frame_rate_api.js
@@ -1,0 +1,37 @@
+var space = require("../../public/space");
+var interopUtils = require("./emscripten_interop_utils.js");
+
+function EmscriptenFrameRateApi(emscriptenApiPointer, cwrap, runtime, emscriptenMemory) {
+
+    var _emscriptenApiPointer = emscriptenApiPointer;
+    var _emscriptenMemory = emscriptenMemory;
+
+    var _frameRateApi_SetTargetVSyncInterval = cwrap("frameRateApi_SetTargetVSyncInterval", null, ["number", "number"]);
+    var _frameRateApi_SetThrottledTargetFrameInterval = cwrap("frameRateApi_SetThrottledTargetFrameInterval", null, ["number", "number"]);
+    var _frameRateApi_SetIdleSecondsBeforeThrottle = cwrap("frameRateApi_SetIdleSecondsBeforeThrottle", null, ["number", "number"]);
+    var _frameRateApi_SetThrottleWhenIdleEnabled = cwrap("frameRateApi_SetThrottleWhenIdleEnabled", null, ["number", "number"]);
+    var _frameRateApi_CancelThrottle = cwrap("frameRateApi_CancelThrottle", null, ["number"]);
+
+    this.setTargetVSyncInterval = function(targetVSyncInterval) {
+        _frameRateApi_SetTargetVSyncInterval(_emscriptenApiPointer, targetVSyncInterval);
+    };
+
+    this.setThrottledTargetFrameInterval = function(throttledTargetFrameIntervalMS) {
+        _frameRateApi_SetThrottledTargetFrameInterval(_emscriptenApiPointer, throttledTargetFrameIntervalMS);
+    };
+
+    this.setIdleSecondsBeforeThrottle = function(idleSecondsBeforeThrottle) {
+        _frameRateApi_SetIdleSecondsBeforeThrottle(_emscriptenApiPointer, idleSecondsBeforeThrottle);
+    };
+
+    this.setThrottleWhenIdleEnabled = function(enabled) {
+        _frameRateApi_SetThrottleWhenIdleEnabled(_emscriptenApiPointer, enabled ? 1 : 0);
+    };
+
+    this.cancelThrottle = function() {
+        _frameRateApi_CancelThrottle(_emscriptenApiPointer);
+    };
+
+}
+
+module.exports = EmscriptenFrameRateApi;

--- a/src/private/frame_rate_module.js
+++ b/src/private/frame_rate_module.js
@@ -1,0 +1,65 @@
+var MapModule = require("./map_module");
+
+
+function FrameRateModule(
+    emscriptenApi,
+    targetVSyncInterval,
+    throttledTargetFrameIntervalMilliseconds,
+    idleSecondsBeforeThrottle,
+    throttleWhenIdleEnabled
+    ) {
+
+    var _emscriptenApi = emscriptenApi;
+    var _targetVSyncInterval = targetVSyncInterval;
+    var _throttledTargetFrameIntervalMilliseconds = throttledTargetFrameIntervalMilliseconds;
+    var _idleSecondsBeforeThrottle = idleSecondsBeforeThrottle;
+    var _throttleWhenIdleEnabled = throttleWhenIdleEnabled;
+    var _ready = false;
+
+    this.onInitialized = function() {
+        _emscriptenApi.frameRateApi.setTargetVSyncInterval(_targetVSyncInterval);
+        _emscriptenApi.frameRateApi.setThrottledTargetFrameInterval(_throttledTargetFrameIntervalMilliseconds);
+        _emscriptenApi.frameRateApi.setIdleSecondsBeforeThrottle(_idleSecondsBeforeThrottle);
+        _emscriptenApi.frameRateApi.setThrottleWhenIdleEnabled(_throttleWhenIdleEnabled);
+        _ready = true;
+    };
+
+    this.ready = function() {
+        return _ready;
+    };
+
+    this.setTargetVSyncInterval = function(targetVSyncInterval) {
+        _targetVSyncInterval = targetVSyncInterval;
+        if (!_ready) {
+            return;
+        }
+        _emscriptenApi.frameRateApi.setTargetVSyncInterval(_targetVSyncInterval);
+    };
+
+    this.setThrottledTargetFrameInterval = function(throttledTargetFrameIntervalMilliseconds) {
+        _throttledTargetFrameIntervalMilliseconds = throttledTargetFrameIntervalMilliseconds;
+        if (!_ready) {
+            return;
+        }
+        _emscriptenApi.frameRateApi.setThrottledTargetFrameInterval(_throttledTargetFrameIntervalMilliseconds);
+    };
+
+    this.setIdleSecondsBeforeThrottle = function(idleSecondsBeforeThrottle) {
+        _idleSecondsBeforeThrottle = idleSecondsBeforeThrottle;
+        if (!_ready) {
+            return;
+        }
+        _emscriptenApi.frameRateApi.setIdleSecondsBeforeThrottle(_idleSecondsBeforeThrottle);
+    };
+
+    this.setThrottleWhenIdleEnabled = function(throttleWhenIdleEnabled) {
+        _throttleWhenIdleEnabled = throttleWhenIdleEnabled;
+        if (!_ready) {
+            return;
+        }
+        _emscriptenApi.frameRateApi.setThrottleWhenIdleEnabled(_throttleWhenIdleEnabled);
+    };
+}
+FrameRateModule.prototype = MapModule;
+
+module.exports = FrameRateModule;

--- a/src/private/frame_rate_module.js
+++ b/src/private/frame_rate_module.js
@@ -59,6 +59,14 @@ function FrameRateModule(
         }
         _emscriptenApi.frameRateApi.setThrottleWhenIdleEnabled(_throttleWhenIdleEnabled);
     };
+
+    this.cancelThrottle = function() {
+        // don't attempt to defer command if called during startup
+        if (!_ready) {
+            return;
+        }
+        _emscriptenApi.frameRateApi.cancelThrottle();
+    };
 }
 FrameRateModule.prototype = MapModule;
 

--- a/src/public/eegeo_leaflet_map.js
+++ b/src/public/eegeo_leaflet_map.js
@@ -66,6 +66,7 @@ var EegeoLeafletMap = L.Map.extend({
         this._polygonModule = polygonModule;
         this._polylineModule = polylineModule;
         this._layerPointMappingModule = layerPointMappingModule;
+        this._frameRateModule = frameRateModule;
         this.themes = themesModule;
         this.indoors = indoorsModule;
         this.routes = routingModule;
@@ -79,7 +80,6 @@ var EegeoLeafletMap = L.Map.extend({
         this.blueSphere = blueSphereModule;
         this.versionModule = versionModule;
         this.heatmaps = heatmapModule;
-        this.frameRate = frameRateModule;
         this._mapRuntimeModule = mapRuntimeModule;
         this._layersOnMap = {};
         this._spacesApi = null;
@@ -465,6 +465,26 @@ var EegeoLeafletMap = L.Map.extend({
 
     setDrawClearColor: function(clearColor) {
         this.rendering.setClearColor(clearColor);
+    },
+
+    setTargetVSyncInterval: function(targetVSyncInterval) {
+        this._frameRateModule.setTargetVSyncInterval(targetVSyncInterval);
+    },
+
+    setThrottledTargetFrameInterval: function(throttledTargetFrameIntervalMilliseconds) {
+        this._frameRateModule.setThrottledTargetFrameInterval(throttledTargetFrameIntervalMilliseconds);
+    },
+
+    setIdleSecondsBeforeThrottle: function(idleSecondsBeforeThrottle) {
+        this._frameRateModule.setIdleSecondsBeforeThrottle(idleSecondsBeforeThrottle);
+    },
+
+    setThrottleWhenIdleEnabled: function(throttleWhenIdleEnabled) {
+        this._frameRateModule.setThrottleWhenIdleEnabled(throttleWhenIdleEnabled);
+    },
+
+    cancelFrameRateThrottle: function() {
+        this._frameRateModule.cancelThrottle();
     },
 
     _getAngleFromCameraToHorizon: function() {

--- a/src/public/eegeo_leaflet_map.js
+++ b/src/public/eegeo_leaflet_map.js
@@ -57,7 +57,8 @@ var EegeoLeafletMap = L.Map.extend({
             blueSphereModule,
             mapRuntimeModule,
             versionModule,
-            heatmapModule
+            heatmapModule,
+            frameRateModule
             ) {
         this._browserWindow = browserWindow;
         this._cameraModule = cameraModule;
@@ -78,6 +79,7 @@ var EegeoLeafletMap = L.Map.extend({
         this.blueSphere = blueSphereModule;
         this.versionModule = versionModule;
         this.heatmaps = heatmapModule;
+        this.frameRate = frameRateModule;
         this._mapRuntimeModule = mapRuntimeModule;
         this._layersOnMap = {};
         this._spacesApi = null;

--- a/tests/interop/api_point_test.js
+++ b/tests/interop/api_point_test.js
@@ -843,4 +843,51 @@ describe("map_interop:", function() {
     });
   });
 
+  describe("when using the frame rate api", function() {
+    var EmscriptenFrameRateApi = require("../../src/private/emscripten_api/emscripten_frame_rate_api");
+    var EmscriptenMemory = require("../../src/private/emscripten_api/emscripten_memory");
+    var _frameRateApi = null;
+    var _emscriptenMemory = null;
+
+    beforeEach(function() {
+      refreshSdk();
+      var apiPointer = 0;
+      var cwrap = Module.cwrap;
+      var runtime = Module.Runtime;
+      _emscriptenMemory = new EmscriptenMemory(Module);
+      _frameRateApi = new EmscriptenFrameRateApi(apiPointer, cwrap, runtime, _emscriptenMemory);
+    });
+
+    it("the setTargetVSyncInterval function must exist", function() {
+      _verifyApiFunctionExists(function() {
+        _frameRateApi.setTargetVSyncInterval(1);
+      });
+    });
+
+    it("the setThrottledTargetFrameInterval function must exist", function() {
+      _verifyApiFunctionExists(function() {
+        _frameRateApi.setThrottledTargetFrameInterval(1);
+      });
+    });
+
+    it("the setIdleSecondsBeforeThrottle function must exist", function() {
+      _verifyApiFunctionExists(function() {
+        _frameRateApi.setIdleSecondsBeforeThrottle(1);
+      });
+    });
+
+    it("the setThrottleWhenIdleEnabled function must exist", function() {
+      _verifyApiFunctionExists(function() {
+        _frameRateApi.setThrottleWhenIdleEnabled(true);
+      });
+    });
+
+    it("the cancelThrottle function must exist", function() {
+      _verifyApiFunctionExists(function() {
+        _frameRateApi.cancelThrottle();
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
add api to allow control of target framerate, optionally throttling framerate after an idle period with no user input.

Some rename + unit change of existing undocumented L.Wrld.map options, these are being fixed up at single known callsite (internal project)