### PR TITLE
Don't set background colour twice

### DIFF
--- a/src/private/eegeo_map_controller.js
+++ b/src/private/eegeo_map_controller.js
@@ -116,7 +116,7 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
     var _canvasHeight = options["height"] || domElement.clientHeight;
     var _containerId = "wrld-map-container" + _mapId;
 
-    var _mapContainer = new HTMLMapContainer(_browserDocument, _browserWindow, domElement, _canvasId, _canvasWidth, _canvasHeight, options.drawClearColor, _containerId, _mapId);
+    var _mapContainer = new HTMLMapContainer(_browserDocument, _browserWindow, domElement, _canvasId, _canvasWidth, _canvasHeight, _containerId, _mapId);
 
     var _canvas = _mapContainer.canvas;
 

--- a/src/private/html_map_container.js
+++ b/src/private/html_map_container.js
@@ -1,4 +1,4 @@
-var HTMLMapContainer = function(browserDocument, browserWindow, parentElement, canvasId, canvasWidth, canvasHeight, backgroundColor, containerId, mapId) {
+var HTMLMapContainer = function(browserDocument, browserWindow, parentElement, canvasId, canvasWidth, canvasHeight, containerId, mapId) {
 
     var _browserWindow = browserWindow;
     var _browserDocument = browserDocument;
@@ -82,7 +82,7 @@ var HTMLMapContainer = function(browserDocument, browserWindow, parentElement, c
         return errorMessage;
     };
 
-    var _createCanvas = function(parentElement, canvasId, width, height, backgroundColor) {
+    var _createCanvas = function(parentElement, canvasId, width, height) {
         var attributes = {
             "class": "wrld-map-canvas",
             "id": canvasId,
@@ -90,10 +90,7 @@ var HTMLMapContainer = function(browserDocument, browserWindow, parentElement, c
             "width": width.toString(),
             "height": height.toString()
         };
-        var style = {
-            "background-color": backgroundColor
-        };
-        var canvas = _createDOMElement(parentElement, "canvas", attributes, style);
+        var canvas = _createDOMElement(parentElement, "canvas", attributes, {});
 
         return canvas;
     };
@@ -134,7 +131,7 @@ var HTMLMapContainer = function(browserDocument, browserWindow, parentElement, c
     this.loadingSpinnerIcon = _createLoadingSpinner(this.mapContainer);
     this.overlay = _createLeafletOverlay(this.mapContainer);
     this.indoorMapWatermark = _createIndoorMapWatermark(this.mapContainer);
-    this.canvas = _createCanvas(this.mapContainer, canvasId, canvasWidth, canvasHeight, backgroundColor);
+    this.canvas = _createCanvas(this.mapContainer, canvasId, canvasWidth, canvasHeight);
 
     this.loadingSpinner = new LoadingSpinner(_browserWindow, this.loadingSpinnerIcon);
     this.loadingSpinner.startSpinning();


### PR DESCRIPTION
Previously, we were setting the draw clear colour both as the WebGL clear colour and the background colour of the HTML canvas. In the case where it was translucent, the colour contributed twice what it was supposed to, and in the case where it was opaque, you couldn't see the canvas' background colour anyway, so it was pointless.

Rendering the map onto a transparent background isn't actually supported, so, bugs notwithstanding, we always hit the pointless case.