### PR TITLE
Add getFloorZOrder to IndoorMapFloor

### DIFF
--- a/src/public/indoors/indoor_map_floor.js
+++ b/src/public/indoors/indoor_map_floor.js
@@ -7,33 +7,36 @@ var IndoorMapFloor = function (floorId, floorIndex, floorName, floorShortName) {
     /**
      * Returns the short name of the floor.
      *
-     * Retain compat with existing API – id was exposed as short name,
-     * whereas it should really be the floorId (a.k.a. z_order).
+     * Note: this is for compatibility with the existing API – the short name was exposed as id. The actual id property in the submission json is not accessible through this API.
      *
      * @deprecated use {@link IndoorMapFloor#getFloorShortName} instead.
+     * @returns {string}
      */
     this.getFloorId = function () {
         return _floorShortName;
     };
 
     /**
-     * Returns the floor id, which matches the z_order in the json submission.
+     * Returns the z_order of the floor, as defined in the json submission.
      * 
-     *  @deprecated use {@link IndoorMapFloor#getFloorZOrder} 
+     * Note: this is for compatibility with the existing API. The actual id property in the submission json is not accessible through this API.
+     * 
+     * @deprecated use {@link IndoorMapFloor#getFloorZOrder}
+     * @returns {number}
      */
     this._getFloorId = function () {
         return _floorId;
     };
 
     /**
-     * Returns the floor id, which matches with the z_order in the json submission.
+     * @returns {number} the z_order of the floor, as defined in the json submission.
      */
     this.getFloorZOrder = function () {
         return _floorId;
     };
 
     /**
-     * Returns the index of the floor array.
+     * @returns {number} the index of this floor in the array.
      */
     this.getFloorIndex = function () {
         return _floorIndex;

--- a/src/public/indoors/indoor_map_floor.js
+++ b/src/public/indoors/indoor_map_floor.js
@@ -1,31 +1,51 @@
-var IndoorMapFloor = function(floorId, floorIndex, floorName, floorShortName) {
+var IndoorMapFloor = function (floorId, floorIndex, floorName, floorShortName) {
     var _floorId = floorId;
     var _floorIndex = floorIndex;
     var _floorName = floorName;
     var _floorShortName = floorShortName;
 
-    this.getFloorId = function() {
-        // retain compat with existing API -- id was exposed as short name
-        // whereas it should really be the floorId (a.k.a. z_order)
+    /**
+     * Returns the short name of the floor.
+     *
+     * Retain compat with existing API – id was exposed as short name,
+     * whereas it should really be the floorId (a.k.a. z_order).
+     *
+     * @deprecated use {@link IndoorMapFloor#getFloorShortName} instead.
+     */
+    this.getFloorId = function () {
         return _floorShortName;
     };
-    
-    this._getFloorId = function() {
+
+    /**
+     * Returns the floor id, which matches the z_order in the json submission.
+     * 
+     *  @deprecated use {@link IndoorMapFloor#getFloorZOrder} 
+     */
+    this._getFloorId = function () {
         return _floorId;
     };
 
-    this.getFloorIndex = function() {
+    /**
+     * Returns the floor id, which matches with the z_order in the json submission.
+     */
+    this.getFloorZOrder = function () {
+        return _floorId;
+    };
+
+    /**
+     * Returns the index of the floor array.
+     */
+    this.getFloorIndex = function () {
         return _floorIndex;
     };
 
-    this.getFloorName = function() {
+    this.getFloorName = function () {
         return _floorName;
     };
 
-    this.getFloorShortName = function() {
+    this.getFloorShortName = function () {
         return _floorShortName;
     };
-
 };
 
 module.exports = IndoorMapFloor;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -328,14 +328,24 @@ declare namespace indoors {
         getIndoorMapId(): IndoorMapId;
         getIndoorMapName(): string;
         getFloorCount(): number;
-        getFloors(): IndoorMapFloor;
+        getFloors(): IndoorMapFloor[];
         getSearchTags(): { name: string; search_tag: string; icon_key: string}[];
     }
 
     class IndoorMapFloor {
-        // retain compat with existing API -- id was exposed as short name
-        // whereas it should really be the floorId (a.k.a. z_order)
+        /**
+         * Returns the short name of the floor.
+         *
+         * Retain compat with existing API – id was exposed as short name,
+         * whereas it should really be the floorId (a.k.a. z_order).
+         *
+         * @deprecated use {@link IndoorMapFloor#getFloorShortName} instead.
+        */
         getFloorId(): string;
+        /**
+         * Returns the floor id, which matches with the z_order in the json submission.
+        */
+        getFloorZOrder(): string;
         getFloorIndex(): number;
         getFloorName(): string;
         getFloorShortName(): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -336,14 +336,14 @@ declare namespace indoors {
         /**
          * Returns the short name of the floor.
          *
-         * Retain compat with existing API – id was exposed as short name,
-         * whereas it should really be the floorId (a.k.a. z_order).
+         * Note: this is for compatibility with the existing API – the short name was exposed as id. The actual id property in the submission json is not accessible through this API.
          *
          * @deprecated use {@link IndoorMapFloor#getFloorShortName} instead.
-        */
+         * @returns {string}
+         */
         getFloorId(): string;
         /**
-         * Returns the floor id, which matches with the z_order in the json submission.
+         * @returns {number} the z_order of the floor, as defined in the json submission.
         */
         getFloorZOrder(): number;
         getFloorIndex(): number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -345,7 +345,7 @@ declare namespace indoors {
         /**
          * Returns the floor id, which matches with the z_order in the json submission.
         */
-        getFloorZOrder(): string;
+        getFloorZOrder(): number;
         getFloorIndex(): number;
         getFloorName(): string;
         getFloorShortName(): string;


### PR DESCRIPTION
I noticed that the type definitions were missing _getFloorId, which is to be expected because it is a private method.

On the other hand, there was no other way of getting the equivalent with a public method.

I have added getFloorZOrder, which does what it says on the tin, marked the other two methods as deprecated pointing towards their more aptly named versions.

Bonus: `IndoorMapFloor` in the type definitions was not an array, as I think it should be.