### PR TITLE
Fix automated tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
         "Module" : true
     },
     "rules": {
+        "@typescript-eslint/no-namespace": ["error", {"allowDeclarations": true}],
         "quotes": [
             "error",
             "double"

--- a/src/__tests__/__mocks__/mockIndoorMapFloorOutlines.ts
+++ b/src/__tests__/__mocks__/mockIndoorMapFloorOutlines.ts
@@ -1,4 +1,4 @@
-import { indoorMapFloorOutlines } from "../../../types";
+import indoorMapFloorOutlines from "../../../types/indoorMapFloorOutlines";
 
 import IndoorMapFloorOutlinePolygon from "../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon";
 import IndoorMapFloorOutlinePolygonRing from "../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring";

--- a/src/__tests__/__mocks__/mockMap.ts
+++ b/src/__tests__/__mocks__/mockMap.ts
@@ -1,4 +1,4 @@
-import { Map } from "../../../types";
+import Map from "../../../types/map";
 
 import Wrld from "../../wrld";
 

--- a/src/__tests__/public/indoorMapFloorOutlines/indoor_map_floor_outline_information.test.ts
+++ b/src/__tests__/public/indoorMapFloorOutlines/indoor_map_floor_outline_information.test.ts
@@ -1,4 +1,4 @@
-import Wrld from "../../../../types";
+import indoorMapFloorOutlines from "../../../../types/indoorMapFloorOutlines";
 
 import { IndoorMapFloorOutlineInformation } from "../../../public/indoorMapFloorOutlines/indoor_map_floor_outline_information";
 
@@ -6,7 +6,7 @@ import { createMockMap } from "../../__mocks__/mockMap";
 import { createMockIndoorMapFloorOutlinePolygon } from "../../__mocks__/mockIndoorMapFloorOutlines";
 
 describe("IndoorMapFloorOutlineInformation class", () => {
-  let indoorMapFloorOutlineInformation: Wrld.indoorMapFloorOutlines.IndoorMapFloorOutlineInformation;
+  let indoorMapFloorOutlineInformation: indoorMapFloorOutlines.IndoorMapFloorOutlineInformation;
   const indoorMapId = "testId";
   const floorZOrder = 1;
   const outlinePolygons = [createMockIndoorMapFloorOutlinePolygon()];

--- a/src/__tests__/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon.test.ts
+++ b/src/__tests__/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon.test.ts
@@ -1,4 +1,4 @@
-import Wrld from "../../../../types";
+import indoorMapFloorOutlines from "../../../../types/indoorMapFloorOutlines";
 import "wrld.js";
 
 import IndoorMapFloorOutlinePolygon from "../../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon";
@@ -6,7 +6,7 @@ import IndoorMapFloorOutlinePolygon from "../../../public/indoorMapFloorOutlines
 import { createMockIndoorMapFloorOutlinePolygonRing } from "../../__mocks__/mockIndoorMapFloorOutlines";
 
 describe("IndoorMapFloorOutlinePolygon class", () => {
-  let indoorMapFloorOutlinePolygon: Wrld.indoorMapFloorOutlines.IndoorMapFloorOutlinePolygon;
+  let indoorMapFloorOutlinePolygon: indoorMapFloorOutlines.IndoorMapFloorOutlinePolygon;
   const outerRing = createMockIndoorMapFloorOutlinePolygonRing();
   const innerRings = createMockIndoorMapFloorOutlinePolygonRing();
 

--- a/src/__tests__/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring.test.ts
+++ b/src/__tests__/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring.test.ts
@@ -1,10 +1,10 @@
-import Wrld from "../../../../types";
+import indoorMapFloorOutlines from "../../../../types/indoorMapFloorOutlines";
 import "wrld.js";
 
 import IndoorMapFloorOutlinePolygonRing from "../../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring";
 
 describe("IndoorMapFloorOutlinePolygonRing class", () => {
-  let indoorMapFloorOutlinePolygonRing: Wrld.indoorMapFloorOutlines.IndoorMapFloorOutlinePolygonRing;
+  let indoorMapFloorOutlinePolygonRing: indoorMapFloorOutlines.IndoorMapFloorOutlinePolygonRing;
   const latLngPoints = [L.latLng(0, 0)];
 
   beforeEach(() => {

--- a/src/__tests__/public/indoors/indoor_map.test.ts
+++ b/src/__tests__/public/indoors/indoor_map.test.ts
@@ -1,20 +1,20 @@
-import Wrld from "../../../../types";
+import indoors from "../../../../types/indoors";
 
 import IndoorMap from "../../../public/indoors/indoor_map";
 import IndoorMapFloor from "../../../public/indoors/indoor_map_floor";
 
 describe("IndoorMap class", () => {
-  let entrance: Wrld.indoors.IndoorMap;
+  let entrance: indoors.IndoorMap;
   const indoorMapId = "testId";
   const indoorMapName = "testName";
   const indoorMapSourceVendor = "testSourceVendor";
   // Floor creation logic is buried in the indoors module and can't make use of it here
   const floorCount = 2;
-  const floors: Wrld.indoors.IndoorMapFloor[] = [];
+  const floors: indoors.IndoorMapFloor[] = [];
   for (let i = 0; i < floorCount; ++i) {
     floors.push(new IndoorMapFloor(i, i, `Floor ${i}`, i.toString()));
   }
-  const searchTags: Wrld.indoors.SearchTag[] = [
+  const searchTags: indoors.SearchTag[] = [
     {
       name: "name",
       search_tag: "search_tag",

--- a/src/__tests__/public/indoors/indoor_map_entrance.test.ts
+++ b/src/__tests__/public/indoors/indoor_map_entrance.test.ts
@@ -1,10 +1,10 @@
-import Wrld from "../../../../types";
+import indoors from "../../../../types/indoors";
 import "wrld.js";
 
 import IndoorMapEntrance from "../../../public/indoors/indoor_map_entrance";
 
 describe("IndoorMapEntrance class", () => {
-  let entrance: Wrld.indoors.IndoorMapEntrance;
+  let entrance: indoors.IndoorMapEntrance;
   const mapId = "testId";
   const mapName = "testName";
   const lat = 56.459233;

--- a/src/__tests__/public/indoors/indoor_map_floor.test.ts
+++ b/src/__tests__/public/indoors/indoor_map_floor.test.ts
@@ -1,9 +1,9 @@
-import Wrld from "../../../../types";
+import indoors from "../../../../types/indoors";
 
 import IndoorMapFloor from "../../../public/indoors/indoor_map_floor";
 
 describe("IndoorMapFloor class", () => {
-  let floor: Wrld.indoors.IndoorMapFloor;
+  let floor: indoors.IndoorMapFloor;
   const floorZOrder = 1;
   const floorIndex = 0;
   const floorName = "Ground Floor";

--- a/src/__tests__/wrld.test.ts
+++ b/src/__tests__/wrld.test.ts
@@ -1,4 +1,4 @@
-import { MapOptions } from "../../types";
+import Map from "../../types/map";
 
 import Wrld from "../wrld";
 
@@ -6,7 +6,7 @@ describe("Wrld.map", () => {
   const elementId = "map";
   let element: HTMLElement | null;
   const apiKey = "testApiKey";
-  let options: MapOptions;
+  let options: Map.Options;
 
   beforeEach(() => {
     element = null;

--- a/types/event.ts
+++ b/types/event.ts
@@ -1,6 +1,7 @@
-export interface WrldEvent<T = string> {
-  type: T;
-  target: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface WrldEvent<TYPE = string, TARGET = any> {
+  type: TYPE;
+  target: TARGET;
 }
 
-export type EventHandler<T extends WrldEvent = WrldEvent<any>> = (e: T) => void
+export type EventHandler<T extends WrldEvent = WrldEvent> = (e: T) => void

--- a/types/heatmap.ts
+++ b/types/heatmap.ts
@@ -51,6 +51,11 @@ declare namespace Heatmap {
     textureBorderPercent?: number;
     useApproximation?: boolean;
   };
+
+  type Heatmaps = {
+    addHeatmap: (heatmap: Heatmap) => void;
+    removeHeatmap: (heatmap: Heatmap) => void;
+  }
 }
 
 declare class Heatmap extends L.Layer {

--- a/types/map.ts
+++ b/types/map.ts
@@ -7,6 +7,7 @@ import type indoorMapEntities from "./indoorMapEntities";
 import type indoorMapFloorOutlines from "./indoorMapFloorOutlines";
 import type { Color } from "./color";
 import type themes from "./themes";
+import type routes from "./routes";
 import type Heatmap from "./heatmap";
 
 declare namespace Map {
@@ -83,26 +84,9 @@ interface Map extends L.Map {
   buildings: buildings.Buildings;
   indoorMapEntities: indoorMapEntities.IndoorMapEntities;
   indoorMapFloorOutlines: indoorMapFloorOutlines.IndoorMapFloorOutlines;
-  themes: {
-    setTheme: (season: themes.season, time: themes.time, weather: themes.weather) => void,
-    setSeason: (season: themes.season) => void,
-    setTime: (time: themes.time) => void,
-    setWeather: (weather: themes.weather) => void,
-    setEnvironmentThemesManifest: (manifest: string) => void,
-  };
-  routes: {
-    getRoutes: (
-      viaPoints: ([number, number] | [number, number, number])[],
-      onLoadHandler: (points: L.LatLng[]) => void,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onErrorHandler: (error: Record<string, any>) => void,
-      transportModule: "walking" | "driving"
-    ) => void
-  };
-  heatmaps: {
-    addHeatmap: (heatmap: Heatmap) => void;
-    removeHeatmap: (heatmap: Heatmap) => void;
-  };
+  themes: themes.Themes;
+  routes: routes.Routes;
+  heatmaps: Heatmap.Heatmaps;
 }
 
 export default Map;

--- a/types/map.ts
+++ b/types/map.ts
@@ -6,6 +6,8 @@ import type buildings from "./buildings";
 import type indoorMapEntities from "./indoorMapEntities";
 import type indoorMapFloorOutlines from "./indoorMapFloorOutlines";
 import type { Color } from "./color";
+import type themes from "./themes";
+import type Heatmap from "./heatmap";
 
 declare namespace Map {
   type MapId = string;
@@ -81,11 +83,26 @@ interface Map extends L.Map {
   buildings: buildings.Buildings;
   indoorMapEntities: indoorMapEntities.IndoorMapEntities;
   indoorMapFloorOutlines: indoorMapFloorOutlines.IndoorMapFloorOutlines;
-
-  // TODO
-  themes: any;
-  routes: any;
-  heatmaps: any;
+  themes: {
+    setTheme: (season: themes.season, time: themes.time, weather: themes.weather) => void,
+    setSeason: (season: themes.season) => void,
+    setTime: (time: themes.time) => void,
+    setWeather: (weather: themes.weather) => void,
+    setEnvironmentThemesManifest: (manifest: string) => void,
+  };
+  routes: {
+    getRoutes: (
+      viaPoints: ([number, number] | [number, number, number])[],
+      onLoadHandler: (points: L.LatLng[]) => void,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onErrorHandler: (error: Record<string, any>) => void,
+      transportModule: "walking" | "driving"
+    ) => void
+  };
+  heatmaps: {
+    addHeatmap: (heatmap: Heatmap) => void;
+    removeHeatmap: (heatmap: Heatmap) => void;
+  };
 }
 
 export default Map;

--- a/types/routes.ts
+++ b/types/routes.ts
@@ -1,0 +1,15 @@
+declare namespace routes {
+  export type Point = [number, number] | [number, number, number];
+
+  export type Routes = {
+    getRoutes: (
+      viaPoints: routes.Point[],
+      onLoadHandler: (points: L.LatLng[]) => void,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onErrorHandler: (error: Record<string, any>) => void,
+      transportModule: "walking" | "driving"
+    ) => void;
+  };
+}
+
+export default routes;

--- a/types/themes.ts
+++ b/types/themes.ts
@@ -20,6 +20,14 @@ declare namespace themes {
     Rainy = "Rainy",
     Snowy = "Snowy",
   }
+
+  type Themes = {
+    setTheme: (season: themes.season, time: themes.time, weather: themes.weather) => void,
+    setSeason: (season: themes.season) => void,
+    setTime: (time: themes.time) => void,
+    setWeather: (weather: themes.weather) => void,
+    setEnvironmentThemesManifest: (manifest: string) => void,
+  }
 }
 
 export default themes;


### PR DESCRIPTION
# Summary

Fixes the automated test results after the changes to the TypeScript definitions.

- Correctly import types in unit tests
- Allow namespace declarations in ESLint
- Organize `any`s and remove warning where appropriate
- Add missing type definitions for `heatmaps`, `routes` and `themes`