### PR TITLE
Bundle using `microbundle`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ example/
 node_modules/
 tests/
 tmp/
+covarage/

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,4 @@ example/
 node_modules/
 tests/
 tmp/
-covarage/
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 src/*.bk
 src/*.tmp
 tmp/
+coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+# Files not be included in the npm package
+/coverage
+test.sh
+issue_template.md

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    ["@babel/preset-env", { "targets": { "node": "current" } }],
+    "@babel/preset-typescript"
+  ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,0 @@
-
-module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "jsdom",
-  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"]
-};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from "@jest/types";
+
+const config: Config.InitialOptions = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
+  transform: { "\\.[jt]sx?$": "babel-jest" },
+  clearMocks: true,
+  collectCoverage: true,
+};
+
+export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config.InitialOptions = {
   transform: { "\\.[jt]sx?$": "babel-jest" },
   clearMocks: true,
   collectCoverage: true,
+  collectCoverageFrom: ["./src/**"]
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,26 +14,26 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
-      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
-      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
+      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-compilation-targets": "^7.14.5",
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.6",
-        "@babel/parser": "^7.14.6",
+        "@babel/generator": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.0",
+        "@babel/helper-module-transforms": "^7.15.0",
+        "@babel/helpers": "^7.14.8",
+        "@babel/parser": "^7.15.0",
         "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -51,10 +51,21 @@
             "@babel/highlight": "^7.14.5"
           }
         },
+        "@babel/generator": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
           "dev": true
         },
         "@babel/highlight": {
@@ -68,6 +79,39 @@
             "js-tokens": "^4.0.0"
           }
         },
+        "@babel/parser": {
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.0",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "convert-source-map": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -76,6 +120,12 @@
           "requires": {
             "safe-buffer": "~5.1.1"
           }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
         }
       }
     },
@@ -110,12 +160,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-      "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
+      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/compat-data": "^7.15.0",
         "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
@@ -317,12 +367,30 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-      "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-module-imports": {
@@ -335,25 +403,95 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
-      "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
+      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.14.5",
-        "@babel/helper-simple-access": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.0",
+        "@babel/helper-simple-access": "^7.14.8",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
+        "@babel/code-frame": {
           "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.0",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         }
       }
@@ -385,24 +523,120 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-      "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.14.5",
+        "@babel/helper-member-expression-to-functions": "^7.15.0",
         "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.0",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
-      "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.14.8"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -448,14 +682,92 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
-      "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
+      "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.0",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
       }
     },
     "@babel/highlight": {
@@ -991,130 +1303,6 @@
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-simple-access": "^7.14.8",
         "babel-plugin-dynamic-import-node": "^2.3.3"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.14.5"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.15.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-          "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.15.0"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-          "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.14.5",
-            "@babel/helper-replace-supers": "^7.15.0",
-            "@babel/helper-simple-access": "^7.14.8",
-            "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.15.0",
-            "@babel/types": "^7.15.0"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-          "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.15.0",
-            "@babel/helper-optimise-call-expression": "^7.14.5",
-            "@babel/traverse": "^7.15.0",
-            "@babel/types": "^7.15.0"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-          "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.14.8"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.9",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.15.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.14.5",
-            "@babel/generator": "^7.15.0",
-            "@babel/helper-function-name": "^7.14.5",
-            "@babel/helper-hoist-variables": "^7.14.5",
-            "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/parser": "^7.15.0",
-            "@babel/types": "^7.15.0",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        }
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
@@ -1317,6 +1505,17 @@
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.0.tgz",
+      "integrity": "sha512-WIIEazmngMEEHDaPTx0IZY48SaAmjVWe3TRSX7cmJXn0bEv9midFzAjxiruOWYIVf5iQ10vFx7ASDpgEO08L5w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.15.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5"
+      }
+    },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz",
@@ -1417,24 +1616,6 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "@babel/compat-data": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
-          "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
-          "dev": true
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-          "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.15.0",
-            "@babel/helper-validator-option": "^7.14.5",
-            "browserslist": "^4.16.6",
-            "semver": "^6.3.0"
-          }
-        },
         "@babel/helper-validator-identifier": {
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
@@ -1499,6 +1680,17 @@
         "@babel/plugin-transform-react-jsx": "^7.14.5",
         "@babel/plugin-transform-react-jsx-development": "^7.14.5",
         "@babel/plugin-transform-react-pure-annotations": "^7.14.5"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.15.0.tgz",
+      "integrity": "sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-typescript": "^7.15.0"
       }
     },
     "@babel/runtime": {
@@ -1658,19 +1850,32 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.2.tgz",
-      "integrity": "sha512-/zYigssuHLImGeMAACkjI4VLAiiJznHgAl3xnFT19iWyct2LhrH3KXOjHRmxBGTkiPLZKKAJAgaPpiU9EZ9K+w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.0.tgz",
+      "integrity": "sha512-+Vl+xmLwAXLNlqT61gmHEixeRbS4L8MUzAjtpBCOPWH+izNI/dR16IeXjkXJdRtIVWVSf9DO1gdp67B1XorZhQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.0.2",
-        "jest-util": "^27.0.2",
+        "jest-message-util": "^27.1.0",
+        "jest-util": "^27.1.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1681,9 +1886,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1711,6 +1916,26 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -1723,35 +1948,35 @@
       }
     },
     "@jest/core": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.5.tgz",
-      "integrity": "sha512-g73//jF0VwsOIrWUC9Cqg03lU3QoAMFxVjsm6n6yNmwZcQPN/o8w+gLWODw5VfKNFZT38otXHWxc6b8eGDUpEA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.0.tgz",
+      "integrity": "sha512-3l9qmoknrlCFKfGdrmiQiPne+pUR4ALhKwFTYyOeKw6egfDwJkO21RJ1xf41rN8ZNFLg5W+w6+P4fUqq4EMRWA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.2",
-        "@jest/reporters": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.1.0",
+        "@jest/reporters": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.0.2",
-        "jest-config": "^27.0.5",
-        "jest-haste-map": "^27.0.5",
-        "jest-message-util": "^27.0.2",
-        "jest-regex-util": "^27.0.1",
-        "jest-resolve": "^27.0.5",
-        "jest-resolve-dependencies": "^27.0.5",
-        "jest-runner": "^27.0.5",
-        "jest-runtime": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
-        "jest-watcher": "^27.0.2",
+        "jest-changed-files": "^27.1.0",
+        "jest-config": "^27.1.0",
+        "jest-haste-map": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.1.0",
+        "jest-resolve-dependencies": "^27.1.0",
+        "jest-runner": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
+        "jest-watcher": "^27.1.0",
         "micromatch": "^4.0.4",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -1759,6 +1984,19 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1769,9 +2007,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1811,6 +2049,26 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
           "dev": true
         },
         "rimraf": {
@@ -1843,74 +2101,30 @@
       }
     },
     "@jest/environment": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.5.tgz",
-      "integrity": "sha512-IAkJPOT7bqn0GiX5LPio6/e1YpcmLbrd8O5EFYpAOZ6V+9xJDsXjdgN2vgv9WOKIs/uA1kf5WeD96HhlBYO+FA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.0.tgz",
+      "integrity": "sha512-wRp50aAMY2w1U2jP1G32d6FUVBNYqmk8WaGkiIEisU48qyDV0WPtw3IBLnl7orBeggveommAkuijY+RzVnNDOQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
-        "jest-mock": "^27.0.3"
-      }
-    },
-    "@jest/fake-timers": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.5.tgz",
-      "integrity": "sha512-d6Tyf7iDoKqeUdwUKrOBV/GvEZRF67m7lpuWI0+SCD9D3aaejiOQZxAOxwH2EH/W18gnfYaBPLi0VeTGBHtQBg==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.0.2",
-        "@sinonjs/fake-timers": "^7.0.2",
-        "@types/node": "*",
-        "jest-message-util": "^27.0.2",
-        "jest-mock": "^27.0.3",
-        "jest-util": "^27.0.2"
-      }
-    },
-    "@jest/globals": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.5.tgz",
-      "integrity": "sha512-qqKyjDXUaZwDuccpbMMKCCMBftvrbXzigtIsikAH/9ca+kaae8InP2MDf+Y/PdCSMuAsSpHS6q6M25irBBUh+Q==",
-      "dev": true,
-      "requires": {
-        "@jest/environment": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "expect": "^27.0.2"
-      }
-    },
-    "@jest/reporters": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.5.tgz",
-      "integrity": "sha512-4uNg5+0eIfRafnpgu3jCZws3NNcFzhu5JdRd1mKQ4/53+vkIqwB6vfZ4gn5BdGqOaLtYhlOsPaL5ATkKzyBrJw==",
-      "dev": true,
-      "requires": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.0.2",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "chalk": "^4.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "exit": "^0.1.2",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.2.4",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.3",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.0.5",
-        "jest-resolve": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
-        "slash": "^3.0.0",
-        "source-map": "^0.6.0",
-        "string-length": "^4.0.1",
-        "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^8.0.0"
+        "jest-mock": "^27.1.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1921,9 +2135,278 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.0.tgz",
+      "integrity": "sha512-22Zyn8il8DzpS+30jJNVbTlm7vAtnfy1aYvNeOEHloMlGy1PCYLHa4PWlSws0hvNsMM5bON6GISjkLoQUV3oMA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.1.0",
+        "@sinonjs/fake-timers": "^7.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^27.1.0",
+        "jest-mock": "^27.1.0",
+        "jest-util": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/globals": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.0.tgz",
+      "integrity": "sha512-73vLV4aNHAlAgjk0/QcSIzzCZSqVIPbmFROJJv9D3QUR7BI4f517gVdJpSrCHxuRH3VZFhe0yGG/tmttlMll9g==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "expect": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/reporters": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.0.tgz",
+      "integrity": "sha512-5T/zlPkN2HnK3Sboeg64L5eC8iiaZueLpttdktWTJsvALEtP2YMkC5BQxwjRWQACG9SwDmz+XjjkoxXUDMDgdw==",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.2.4",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.3",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "jest-haste-map": "^27.1.0",
+        "jest-resolve": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-worker": "^27.1.0",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^4.0.1",
+        "terminal-link": "^2.0.0",
+        "v8-to-istanbul": "^8.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1965,6 +2448,26 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1983,9 +2486,9 @@
       }
     },
     "@jest/source-map": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.1.tgz",
-      "integrity": "sha512-yMgkF0f+6WJtDMdDYNavmqvbHtiSpwRN2U/W+6uztgfqgkq/PXdKPqjBTUF1RD/feth4rH5N3NW0T5+wIuln1A==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.6.tgz",
+      "integrity": "sha512-Fek4mi5KQrqmlY07T23JRi0e7Z9bXTOOD86V/uS0EIW4PClvPDqZOyFlLpNJheS6QI0FNX1CgmPjtJ4EA/2M+g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
@@ -2002,52 +2505,30 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.2.tgz",
-      "integrity": "sha512-gcdWwL3yP5VaIadzwQtbZyZMgpmes8ryBAJp70tuxghiA8qL4imJyZex+i+USQH2H4jeLVVszhwntgdQ97fccA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.0.tgz",
+      "integrity": "sha512-Aoz00gpDL528ODLghat3QSy6UBTD5EmmpjrhZZMK/v1Q2/rRRqTGnFxHuEkrD4z/Py96ZdOHxIWkkCKRpmnE1A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
-      }
-    },
-    "@jest/test-sequencer": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.5.tgz",
-      "integrity": "sha512-opztnGs+cXzZ5txFG2+omBaV5ge/0yuJNKbhE3DREMiXE0YxBuzyEa6pNv3kk2JuucIlH2Xvgmn9kEEHSNt/SA==",
-      "dev": true,
-      "requires": {
-        "@jest/test-result": "^27.0.2",
-        "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.5",
-        "jest-runtime": "^27.0.5"
-      }
-    },
-    "@jest/transform": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.5.tgz",
-      "integrity": "sha512-lBD6OwKXSc6JJECBNk4mVxtSVuJSBsQrJ9WCBisfJs7EZuYq4K6vM9HmoB7hmPiLIDGeyaerw3feBV/bC4z8tg==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.1.0",
-        "@jest/types": "^27.0.2",
-        "babel-plugin-istanbul": "^6.0.0",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^1.4.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.5",
-        "jest-regex-util": "^27.0.1",
-        "jest-util": "^27.0.2",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.1",
-        "slash": "^3.0.0",
-        "source-map": "^0.6.1",
-        "write-file-atomic": "^3.0.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2058,9 +2539,108 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.0.tgz",
+      "integrity": "sha512-lnCWawDr6Z1DAAK9l25o3AjmKGgcutq1iIbp+hC10s/HxnB8ZkUsYq1FzjOoxxZ5hW+1+AthBtvS4x9yno3V1A==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^27.1.0",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.1.0",
+        "jest-runtime": "^27.1.0"
+      }
+    },
+    "@jest/transform": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.0.tgz",
+      "integrity": "sha512-ZRGCA2ZEVJ00ubrhkTG87kyLbN6n55g1Ilq0X9nJb5bX3MhMp3O6M7KG+LvYu+nZRqG5cXsQnJEdZbdpTAV8pQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^27.1.0",
+        "babel-plugin-istanbul": "^6.0.0",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.1.0",
+        "jest-regex-util": "^27.0.6",
+        "jest-util": "^27.1.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.1",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2097,6 +2677,26 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2115,9 +2715,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-      "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+      "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2137,9 +2737,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2359,9 +2959,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.14",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
-      "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+      "version": "7.1.15",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
+      "integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -2372,18 +2972,18 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
-      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.3.tgz",
+      "integrity": "sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
-      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
+      "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -2391,9 +2991,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
-      "integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
+      "integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -2444,122 +3044,13 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.23",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
-      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
+      "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
       "dev": true,
       "requires": {
-        "jest-diff": "^26.0.0",
-        "pretty-format": "^26.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.13",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-          "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "diff-sequences": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-          "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-          "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^26.6.2",
-            "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.6.2"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.2",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^17.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/json-schema": {
@@ -2589,9 +3080,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
       "dev": true
     },
     "@types/resolve": {
@@ -2604,9 +3095,9 @@
       }
     },
     "@types/stack-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
     "@types/yargs": {
@@ -2932,6 +3423,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3089,16 +3586,16 @@
       }
     },
     "babel-jest": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.5.tgz",
-      "integrity": "sha512-bTMAbpCX7ldtfbca2llYLeSFsDM257aspyAOpsdrdSrBqoLkWCy4HPYTXtXWaSLgFPjrJGACL65rzzr4RFGadw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
+      "integrity": "sha512-6NrdqzaYemALGCuR97QkC/FkFIEBWP5pw5TMJoUHZTVXyOgocujp6A0JE2V6gE0HtqAAv6VKU/nI+OCR1Z4gHA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.0.1",
+        "babel-preset-jest": "^27.0.6",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
@@ -3114,9 +3611,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -3178,9 +3675,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.1.tgz",
-      "integrity": "sha512-sqBF0owAcCDBVEDtxqfYr2F36eSHdx7lAVGyYuOBRnKdD6gzcy0I0XrAYCZgOA3CRrLhmR+Uae9nogPzmAtOfQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
+      "integrity": "sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -3284,12 +3781,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.1.tgz",
-      "integrity": "sha512-nIBIqCEpuiyhvjQs2mVNwTxQQa2xk70p9Dd/0obQGBf8FBzbnI8QhQKzLsWMN2i6q+5B0OcWDtrboBX5gmOLyA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
+      "integrity": "sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^27.0.1",
+        "babel-plugin-jest-hoist": "^27.0.6",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -3715,9 +4212,9 @@
       }
     },
     "cjs-module-lexer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
-      "integrity": "sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
+      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
     "cli-cursor": {
@@ -4021,6 +4518,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -4244,9 +4747,9 @@
       "dev": true
     },
     "decimal.js": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.0.tgz",
-      "integrity": "sha512-MrQRs2gyD//7NeHi9TtsfClkf+cFAewDz+PZHR8ILKglLmBMyVX3ymQ+oeznE3tjrS7beTN+6JXb2C3JDHm7ug==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
     "dedent": {
@@ -4326,10 +4829,16 @@
         "defined": "^1.0.0"
       }
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "diff-sequences": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.1.tgz",
-      "integrity": "sha512-XPLijkfJUh/PIBnfkcSHgvD6tlYixmcMAn3osTk6jt+H0v/mgURto1XUiD9DKuGX5NDoVS6dSlA23gd9FUaCFg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+      "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
       "dev": true
     },
     "diffie-hellman": {
@@ -4835,24 +5344,88 @@
       "dev": true
     },
     "expect": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.2.tgz",
-      "integrity": "sha512-YJFNJe2+P2DqH+ZrXy+ydRQYO87oxRUonZImpDodR1G7qo3NYd3pL+NQ9Keqpez3cehczYwZDBC3A7xk3n7M/w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.1.0.tgz",
+      "integrity": "sha512-9kJngV5hOJgkFil4F/uXm3hVBubUK2nERVfvqNNwxxuW8ZOUwSTTSysgfzckYtv/LBzj/LJXbiAF7okHCXgdug==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.1.0",
         "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.0.1",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-regex-util": "^27.0.1"
+        "jest-get-type": "^27.0.6",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-regex-util": "^27.0.6"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -5769,9 +6342,9 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
     "is-symbol": {
@@ -5923,16 +6496,29 @@
       "dev": true
     },
     "jest": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.5.tgz",
-      "integrity": "sha512-4NlVMS29gE+JOZvgmSAsz3eOjkSsHqjTajlIsah/4MVSmKvf3zFP/TvgcLoWe2UVHiE9KF741sReqhF0p4mqbQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.1.0.tgz",
+      "integrity": "sha512-pSQDVwRSwb109Ss13lcMtdfS9r8/w2Zz8+mTUA9VORD66GflCdl8nUFCqM96geOD2EBwWCNURrNAfQsLIDNBdg==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.0.5",
+        "@jest/core": "^27.1.0",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.0.5"
+        "jest-cli": "^27.1.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -5943,9 +6529,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5985,24 +6571,44 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "27.0.5",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.5.tgz",
-          "integrity": "sha512-kZqY020QFOFQKVE2knFHirTBElw3/Q0kUbDc3nMfy/x+RQ7zUY89SUuzpHHJoSX1kX7Lq569ncvjNqU3Td/FCA==",
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.0.tgz",
+          "integrity": "sha512-h6zPUOUu+6oLDrXz0yOWY2YXvBLk8gQinx4HbZ7SF4V3HzasQf+ncoIbKENUMwXyf54/6dBkYXvXJos+gOHYZw==",
           "dev": true,
           "requires": {
-            "@jest/core": "^27.0.5",
-            "@jest/test-result": "^27.0.2",
-            "@jest/types": "^27.0.2",
+            "@jest/core": "^27.1.0",
+            "@jest/test-result": "^27.1.0",
+            "@jest/types": "^27.1.0",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
-            "jest-config": "^27.0.5",
-            "jest-util": "^27.0.2",
-            "jest-validate": "^27.0.2",
+            "jest-config": "^27.1.0",
+            "jest-util": "^27.1.0",
+            "jest-validate": "^27.1.0",
             "prompts": "^2.0.1",
             "yargs": "^16.0.3"
           }
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -6040,43 +6646,29 @@
       }
     },
     "jest-changed-files": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.2.tgz",
-      "integrity": "sha512-eMeb1Pn7w7x3wue5/vF73LPCJ7DKQuC9wQUR5ebP9hDPpk5hzcT/3Hmz3Q5BOFpR3tgbmaWhJcMTVgC8Z1NuMw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.0.tgz",
+      "integrity": "sha512-eRcb13TfQw0xiV2E98EmiEgs9a5uaBIqJChyl0G7jR9fCIvGjXovnDS6Zbku3joij4tXYcSK4SE1AXqOlUxjWg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.1.0",
         "execa": "^5.0.0",
-        "throat": "^6.0.1"
-      }
-    },
-    "jest-circus": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.5.tgz",
-      "integrity": "sha512-p5rO90o1RTh8LPOG6l0Fc9qgp5YGv+8M5CFixhMh7gGHtGSobD1AxX9cjFZujILgY8t30QZ7WVvxlnuG31r8TA==",
-      "dev": true,
-      "requires": {
-        "@jest/environment": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "dedent": "^0.7.0",
-        "expect": "^27.0.2",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.2",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-runtime": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "pretty-format": "^27.0.2",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6087,9 +6679,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6128,35 +6720,46 @@
         }
       }
     },
-    "jest-config": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.5.tgz",
-      "integrity": "sha512-zCUIXag7QIXKEVN4kUKbDBDi9Q53dV5o3eNhGqe+5zAbt1vLs4VE3ceWaYrOub0L4Y7E9pGfM84TX/0ARcE+Qw==",
+    "jest-circus": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.0.tgz",
+      "integrity": "sha512-6FWtHs3nZyZlMBhRf1wvAC5CirnflbGJAY1xssSAnERLiiXQRH+wY2ptBVtXjX4gz4AA2EwRV57b038LmifRbA==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "babel-jest": "^27.0.5",
+        "@jest/environment": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.2.4",
-        "is-ci": "^3.0.0",
-        "jest-circus": "^27.0.5",
-        "jest-environment-jsdom": "^27.0.5",
-        "jest-environment-node": "^27.0.5",
-        "jest-get-type": "^27.0.1",
-        "jest-jasmine2": "^27.0.5",
-        "jest-regex-util": "^27.0.1",
-        "jest-resolve": "^27.0.5",
-        "jest-runner": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.2"
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "expect": "^27.1.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^27.1.0",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "pretty-format": "^27.1.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3",
+        "throat": "^6.0.1"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6167,9 +6770,122 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-config": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.0.tgz",
+      "integrity": "sha512-GMo7f76vMYUA3b3xOdlcKeKQhKcBIgurjERO2hojo0eLkKPGcw7fyIoanH+m6KOP2bLad+fGnF8aWOJYxzNPeg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "babel-jest": "^27.1.0",
+        "chalk": "^4.0.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.2.4",
+        "is-ci": "^3.0.0",
+        "jest-circus": "^27.1.0",
+        "jest-environment-jsdom": "^27.1.0",
+        "jest-environment-node": "^27.1.0",
+        "jest-get-type": "^27.0.6",
+        "jest-jasmine2": "^27.1.0",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.1.0",
+        "jest-runner": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6211,6 +6927,26 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6223,15 +6959,15 @@
       }
     },
     "jest-diff": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.2.tgz",
-      "integrity": "sha512-BFIdRb0LqfV1hBt8crQmw6gGQHVDhM87SpMIZ45FPYKReZYG5er1+5pIn2zKqvrJp6WNox0ylR8571Iwk2Dmgw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
+      "integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.0.1",
-        "jest-get-type": "^27.0.1",
-        "pretty-format": "^27.0.2"
+        "diff-sequences": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6244,9 +6980,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6286,27 +7022,40 @@
       }
     },
     "jest-docblock": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.1.tgz",
-      "integrity": "sha512-TA4+21s3oebURc7VgFV4r7ltdIJ5rtBH1E3Tbovcg7AV+oLfD5DcJ2V2vJ5zFA9sL5CFd/d2D6IpsAeSheEdrA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.6.tgz",
+      "integrity": "sha512-Fid6dPcjwepTFraz0YxIMCi7dejjJ/KL9FBjPYhBp4Sv1Y9PdhImlKZqYU555BlN4TQKaTc+F2Av1z+anVyGkA==",
       "dev": true,
       "requires": {
         "detect-newline": "^3.0.0"
       }
     },
     "jest-each": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.2.tgz",
-      "integrity": "sha512-OLMBZBZ6JkoXgUenDtseFRWA43wVl2BwmZYIWQws7eS7pqsIvePqj/jJmEnfq91ALk3LNphgwNK/PRFBYi7ITQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.0.tgz",
+      "integrity": "sha512-K/cNvQlmDqQMRHF8CaQ0XPzCfjP5HMJc2bIJglrIqI9fjwpNqITle63IWE+wq4p+3v+iBgh7Wq0IdGpLx5xjDg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.1.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.0.1",
-        "jest-util": "^27.0.2",
-        "pretty-format": "^27.0.2"
+        "jest-get-type": "^27.0.6",
+        "jest-util": "^27.1.0",
+        "pretty-format": "^27.1.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6317,9 +7066,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6345,6 +7094,26 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
           "dev": true
         },
         "supports-color": {
@@ -6359,87 +7128,33 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.5.tgz",
-      "integrity": "sha512-ToWhViIoTl5738oRaajTMgYhdQL73UWPoV4GqHGk2DPhs+olv8OLq5KoQW8Yf+HtRao52XLqPWvl46dPI88PdA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.0.tgz",
+      "integrity": "sha512-JbwOcOxh/HOtsj56ljeXQCUJr3ivnaIlM45F5NBezFLVYdT91N5UofB1ux2B1CATsQiudcHdgTaeuqGXJqjJYQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.5",
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/environment": "^27.1.0",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
-        "jest-mock": "^27.0.3",
-        "jest-util": "^27.0.2",
+        "jest-mock": "^27.1.0",
+        "jest-util": "^27.1.0",
         "jsdom": "^16.6.0"
-      }
-    },
-    "jest-environment-node": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.5.tgz",
-      "integrity": "sha512-47qqScV/WMVz5OKF5TWpAeQ1neZKqM3ySwNveEnLyd+yaE/KT6lSMx/0SOx60+ZUcVxPiESYS+Kt2JS9y4PpkQ==",
-      "dev": true,
-      "requires": {
-        "@jest/environment": "^27.0.5",
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "@types/node": "*",
-        "jest-mock": "^27.0.3",
-        "jest-util": "^27.0.2"
-      }
-    },
-    "jest-get-type": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
-      "dev": true
-    },
-    "jest-haste-map": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.5.tgz",
-      "integrity": "sha512-3LFryGSHxwPFHzKIs6W0BGA2xr6g1MvzSjR3h3D8K8Uqy4vbRm/grpGHzbPtIbOPLC6wFoViRrNEmd116QWSkw==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.0.2",
-        "@types/graceful-fs": "^4.1.2",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
-        "graceful-fs": "^4.2.4",
-        "jest-regex-util": "^27.0.1",
-        "jest-serializer": "^27.0.1",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.7"
-      }
-    },
-    "jest-jasmine2": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.5.tgz",
-      "integrity": "sha512-m3TojR19sFmTn79QoaGy1nOHBcLvtLso6Zh7u+gYxZWGcza4rRPVqwk1hciA5ZOWWZIJOukAcore8JRX992FaA==",
-      "dev": true,
-      "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.0.5",
-        "@jest/source-map": "^27.0.1",
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "expect": "^27.0.2",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.2",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-runtime": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "pretty-format": "^27.0.2",
-        "throat": "^6.0.1"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6450,9 +7165,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6480,6 +7195,345 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-environment-node": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.0.tgz",
+      "integrity": "sha512-JIyJ8H3wVyM4YCXp7njbjs0dIT87yhGlrXCXhDKNIg1OjurXr6X38yocnnbXvvNyqVTqSI4M9l+YfPKueqL1lw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^27.1.0",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "@types/node": "*",
+        "jest-mock": "^27.1.0",
+        "jest-util": "^27.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-get-type": {
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+      "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.0.tgz",
+      "integrity": "sha512-7mz6LopSe+eA6cTFMf10OfLLqRoIPvmMyz5/OnSXnHO7hB0aDP1iIeLWCXzAcYU5eIJVpHr12Bk9yyq2fTW9vg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.1.0",
+        "@types/graceful-fs": "^4.1.2",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
+        "graceful-fs": "^4.2.4",
+        "jest-regex-util": "^27.0.6",
+        "jest-serializer": "^27.0.6",
+        "jest-util": "^27.1.0",
+        "jest-worker": "^27.1.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.7"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-jasmine2": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.0.tgz",
+      "integrity": "sha512-Z/NIt0wBDg3przOW2FCWtYjMn3Ip68t0SL60agD/e67jlhTyV3PIF8IzT9ecwqFbeuUSO2OT8WeJgHcalDGFzQ==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^27.1.0",
+        "@jest/source-map": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "expect": "^27.1.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^27.1.0",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "pretty-format": "^27.1.0",
+        "throat": "^6.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6492,25 +7546,25 @@
       }
     },
     "jest-leak-detector": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.2.tgz",
-      "integrity": "sha512-TZA3DmCOfe8YZFIMD1GxFqXUkQnIoOGQyy4hFCA2mlHtnAaf+FeOMxi0fZmfB41ZL+QbFG6BVaZF5IeFIVy53Q==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
+      "integrity": "sha512-oHvSkz1E80VyeTKBvZNnw576qU+cVqRXUD3/wKXh1zpaki47Qty2xeHg2HKie9Hqcd2l4XwircgNOWb/NiGqdA==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^27.0.1",
-        "pretty-format": "^27.0.2"
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.1.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz",
-      "integrity": "sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.0.tgz",
+      "integrity": "sha512-VmAudus2P6Yt/JVBRdTPFhUzlIN8DYJd+et5Rd9QDsO/Z82Z4iwGjo43U8Z+PTiz8CBvKvlb6Fh3oKy39hykkQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.0.2",
-        "jest-get-type": "^27.0.1",
-        "pretty-format": "^27.0.2"
+        "jest-diff": "^27.1.0",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6523,9 +7577,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6565,18 +7619,18 @@
       }
     },
     "jest-message-util": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.2.tgz",
-      "integrity": "sha512-rTqWUX42ec2LdMkoUPOzrEd1Tcm+R1KfLOmFK+OVNo4MnLsEaxO5zPDb2BbdSmthdM/IfXxOZU60P/WbWF8BTw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.0.tgz",
+      "integrity": "sha512-Eck8NFnJ5Sg36R9XguD65cf2D5+McC+NF5GIdEninoabcuoOfWrID5qJhufq5FB0DRKoiyxB61hS7MKoMD0trQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.1.0",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.2",
+        "pretty-format": "^27.1.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -6591,9 +7645,9 @@
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
           "dev": true
         },
         "@babel/highlight": {
@@ -6620,10 +7674,23 @@
             }
           }
         },
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6674,44 +7741,28 @@
       }
     },
     "jest-mock": {
-      "version": "27.0.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.3.tgz",
-      "integrity": "sha512-O5FZn5XDzEp+Xg28mUz4ovVcdwBBPfAhW9+zJLO0Efn2qNbYcDaJvSlRiQ6BCZUCVOJjALicuJQI9mRFjv1o9Q==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.0.tgz",
+      "integrity": "sha512-iT3/Yhu7DwAg/0HvvLCqLvrTKTRMyJlrrfJYWzuLSf9RCAxBoIXN3HoymZxMnYsC3eD8ewGbUa9jUknwBenx2w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.1.0",
         "@types/node": "*"
-      }
-    },
-    "jest-pnp-resolver": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
-    },
-    "jest-regex-util": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.1.tgz",
-      "integrity": "sha512-6nY6QVcpTgEKQy1L41P4pr3aOddneK17kn3HJw6SdwGiKfgCGTvH02hVXL0GU8GEKtPH83eD2DIDgxHXOxVohQ==",
-      "dev": true
-    },
-    "jest-resolve": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.5.tgz",
-      "integrity": "sha512-Md65pngRh8cRuWVdWznXBB5eDt391OJpdBaJMxfjfuXCvOhM3qQBtLMCMTykhuUKiBMmy5BhqCW7AVOKmPrW+Q==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.0.2",
-        "chalk": "^4.0.0",
-        "escalade": "^3.1.1",
-        "graceful-fs": "^4.2.4",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
-        "resolve": "^1.20.0",
-        "slash": "^3.0.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6722,9 +7773,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6752,10 +7803,124 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
+      "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.0.tgz",
+      "integrity": "sha512-TXvzrLyPg0vLOwcWX38ZGYeEztSEmW+cQQKqc4HKDUwun31wsBXwotRlUz4/AYU/Fq4GhbMd/ileIWZEtcdmIA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.1.0",
+        "chalk": "^4.0.0",
+        "escalade": "^3.1.1",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.1.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
+        "resolve": "^1.20.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
         "path-parse": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
           "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
           "dev": true
         },
         "resolve": {
@@ -6780,46 +7945,29 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.5.tgz",
-      "integrity": "sha512-xUj2dPoEEd59P+nuih4XwNa4nJ/zRd/g4rMvjHrZPEBWeWRq/aJnnM6mug+B+Nx+ILXGtfWHzQvh7TqNV/WbuA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.0.tgz",
+      "integrity": "sha512-Kq5XuDAELuBnrERrjFYEzu/A+i2W7l9HnPWqZEeKGEQ7m1R+6ndMbdXCVCx29Se1qwLZLgvoXwinB3SPIaitMQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
-        "jest-regex-util": "^27.0.1",
-        "jest-snapshot": "^27.0.5"
-      }
-    },
-    "jest-runner": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.5.tgz",
-      "integrity": "sha512-HNhOtrhfKPArcECgBTcWOc+8OSL8GoFoa7RsHGnfZR1C1dFohxy9eLtpYBS+koybAHlJLZzNCx2Y/Ic3iEtJpQ==",
-      "dev": true,
-      "requires": {
-        "@jest/console": "^27.0.2",
-        "@jest/environment": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "emittery": "^0.8.1",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.4",
-        "jest-docblock": "^27.0.1",
-        "jest-environment-jsdom": "^27.0.5",
-        "jest-environment-node": "^27.0.5",
-        "jest-haste-map": "^27.0.5",
-        "jest-leak-detector": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-resolve": "^27.0.5",
-        "jest-runtime": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
-        "source-map-support": "^0.5.6",
-        "throat": "^6.0.1"
+        "@jest/types": "^27.1.0",
+        "jest-regex-util": "^27.0.6",
+        "jest-snapshot": "^27.1.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6830,9 +7978,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6871,40 +8019,49 @@
         }
       }
     },
-    "jest-runtime": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.5.tgz",
-      "integrity": "sha512-V/w/+VasowPESbmhXn5AsBGPfb35T7jZPGZybYTHxZdP7Gwaa+A0EXE6rx30DshHKA98lVCODbCO8KZpEW3hiQ==",
+    "jest-runner": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.0.tgz",
+      "integrity": "sha512-ZWPKr9M5w5gDplz1KsJ6iRmQaDT/yyAFLf18fKbb/+BLWsR1sCNC2wMT0H7pP3gDcBz0qZ6aJraSYUNAGSJGaw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.2",
-        "@jest/environment": "^27.0.5",
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/globals": "^27.0.5",
-        "@jest/source-map": "^27.0.1",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "@types/yargs": "^16.0.0",
+        "@jest/console": "^27.1.0",
+        "@jest/environment": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
-        "cjs-module-lexer": "^1.0.0",
-        "collect-v8-coverage": "^1.0.0",
+        "emittery": "^0.8.1",
         "exit": "^0.1.2",
-        "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.5",
-        "jest-message-util": "^27.0.2",
-        "jest-mock": "^27.0.3",
-        "jest-regex-util": "^27.0.1",
-        "jest-resolve": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0",
-        "yargs": "^16.0.3"
+        "jest-docblock": "^27.0.6",
+        "jest-environment-jsdom": "^27.1.0",
+        "jest-environment-node": "^27.1.0",
+        "jest-haste-map": "^27.1.0",
+        "jest-leak-detector": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-resolve": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-worker": "^27.1.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^6.0.1"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6915,9 +8072,128 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.0.tgz",
+      "integrity": "sha512-okiR2cpGjY0RkWmUGGado6ETpFOi9oG3yV0CioYdoktkVxy5Hv0WRLWnJFuArSYS8cHMCNcceUUMGiIfgxCO9A==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^27.1.0",
+        "@jest/environment": "^27.1.0",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/globals": "^27.1.0",
+        "@jest/source-map": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "execa": "^5.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-mock": "^27.1.0",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0",
+        "yargs": "^16.0.3"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6970,6 +8246,26 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -7006,9 +8302,9 @@
       }
     },
     "jest-serializer": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.1.tgz",
-      "integrity": "sha512-svy//5IH6bfQvAbkAEg1s7xhhgHTtXu0li0I2fdKHDsLP2P2MOiscPQIENQep8oU2g2B3jqLyxKKzotZOz4CwQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.6.tgz",
+      "integrity": "sha512-PtGdVK9EGC7dsaziskfqaAPib6wTViY3G8E5wz9tLVPhHyiDNTZn/xjZ4khAw+09QkoOVpn7vF5nPSN6dtBexA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -7016,9 +8312,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.5.tgz",
-      "integrity": "sha512-H1yFYdgnL1vXvDqMrnDStH6yHFdMEuzYQYc71SnC/IJnuuhW6J16w8GWG1P+qGd3Ag3sQHjbRr0TcwEo/vGS+g==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.0.tgz",
+      "integrity": "sha512-eaeUBoEjuuRwmiRI51oTldUsKOohB1F6fPqWKKILuDi/CStxzp2IWekVUXbuHHoz5ik33ioJhshiHpgPFbYgcA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -7027,26 +8323,39 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.0.2",
+        "expect": "^27.1.0",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.0.2",
-        "jest-get-type": "^27.0.1",
-        "jest-haste-map": "^27.0.5",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-resolve": "^27.0.5",
-        "jest-util": "^27.0.2",
+        "jest-diff": "^27.1.0",
+        "jest-get-type": "^27.0.6",
+        "jest-haste-map": "^27.1.0",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-resolve": "^27.1.0",
+        "jest-util": "^27.1.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.0.2",
+        "pretty-format": "^27.1.0",
         "semver": "^7.3.2"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -7057,9 +8366,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -7087,6 +8396,26 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -7108,12 +8437,12 @@
       }
     },
     "jest-util": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.2.tgz",
-      "integrity": "sha512-1d9uH3a00OFGGWSibpNYr+jojZ6AckOMCXV2Z4K3YXDnzpkAaXQyIpY14FOJPiUmil7CD+A6Qs+lnnh6ctRbIA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+      "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -7131,9 +8460,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -7179,19 +8508,32 @@
       }
     },
     "jest-validate": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.2.tgz",
-      "integrity": "sha512-UgBF6/oVu1ofd1XbaSotXKihi8nZhg0Prm8twQ9uCuAfo59vlxCXMPI/RKmrZEVgi3Nd9dS0I8A0wzWU48pOvg==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.0.tgz",
+      "integrity": "sha512-QiJ+4XuSuMsfPi9zvdO//IrSRSlG6ybJhOpuqYSsuuaABaNT84h0IoD6vvQhThBOKT+DIKvl5sTM0l6is9+SRA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.1.0",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.0.1",
+        "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.0.2"
+        "pretty-format": "^27.1.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -7208,9 +8550,9 @@
           "dev": true
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -7250,20 +8592,33 @@
       }
     },
     "jest-watcher": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.2.tgz",
-      "integrity": "sha512-8nuf0PGuTxWj/Ytfw5fyvNn/R80iXY8QhIT0ofyImUvdnoaBdT6kob0GmhXR+wO+ALYVnh8bQxN4Tjfez0JgkA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.0.tgz",
+      "integrity": "sha512-ivaWTrA46aHWdgPDgPypSHiNQjyKnLBpUIHeBaGg11U+pDzZpkffGlcB1l1a014phmG0mHgkOHtOgiqJQM6yKQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/test-result": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.0.2",
+        "jest-util": "^27.1.0",
         "string-length": "^4.0.1"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -7274,9 +8629,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -7304,6 +8659,26 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "jest-util": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+          "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^3.0.0",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7316,9 +8691,9 @@
       }
     },
     "jest-worker": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.2.tgz",
-      "integrity": "sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
+      "integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -7360,9 +8735,9 @@
       }
     },
     "jsdom": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
-      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "dev": true,
       "requires": {
         "abab": "^2.0.5",
@@ -7390,14 +8765,14 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
+        "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
-          "integrity": "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==",
+          "version": "8.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
           "dev": true
         }
       }
@@ -7909,18 +9284,18 @@
       }
     },
     "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
+      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.48.0"
+        "mime-db": "1.49.0"
       }
     },
     "mimic-fn": {
@@ -8806,22 +10181,86 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-      "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+      "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.1.0",
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+          "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -10186,29 +11625,21 @@
       }
     },
     "ts-jest": {
-      "version": "27.0.3",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.3.tgz",
-      "integrity": "sha512-U5rdMjnYam9Ucw+h0QvtNDbc5+88nxt7tbIvqaZUhFrfG4+SkWhMXjejCLVGcpILTPuV+H3W/GZDZrnZFpPeXw==",
+      "version": "27.0.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.5.tgz",
+      "integrity": "sha512-lIJApzfTaSSbtlksfFNHkWOzLJuuSm4faFAfo5kvzOiRAuoN4/eKxVJ2zEAho8aecE04qX6K1pAzfH5QHL1/8w==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
-        "buffer-from": "1.x",
         "fast-json-stable-stringify": "2.x",
         "jest-util": "^27.0.0",
         "json5": "2.x",
         "lodash": "4.x",
         "make-error": "1.x",
-        "mkdirp": "1.x",
         "semver": "7.x",
         "yargs-parser": "20.x"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -10218,6 +11649,20 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
       }
     },
     "tslib": {
@@ -11113,9 +12558,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
-      "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
       "dev": true,
       "requires": {
         "lodash": "^4.7.0",
@@ -11241,9 +12686,9 @@
       }
     },
     "ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
+      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
       "dev": true
     },
     "xml-name-validator": {
@@ -11298,6 +12743,12 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,25 @@
         "source-map": "^0.5.0"
       }
     },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+      "integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.14.5.tgz",
+      "integrity": "sha512-YTA/Twn0vBXDVGJuAX6PwW7x5zQei1luDDo2Pl6q1qZ7hVNl0RZrhHCQG/ArGpR29Vl7ETiB8eJyrvpuRp300w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      }
+    },
     "@babel/helper-compilation-targets": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
@@ -100,6 +119,172 @@
         "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz",
+      "integrity": "sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-member-expression-to-functions": "^7.15.0",
+        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.0",
+        "@babel/helper-split-export-declaration": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+          "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+          "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.15.0",
+            "@babel/helper-optimise-call-expression": "^7.14.5",
+            "@babel/traverse": "^7.15.0",
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.0",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.5.tgz",
+      "integrity": "sha512-TLawwqpOErY2HhWbGJ2nZT5wSkR192QpN+nBg1THfBfftrlvOh+WbhrxXCH4q4xJ9Gl16BGPR/48JA+Ryiho/A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "regexpu-core": "^4.7.1"
+      }
+    },
+    "@babel/helper-define-polyfill-provider": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+      "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "dependencies": {
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz",
+      "integrity": "sha512-Htb24gnGJdIGT4vnRKMdoXiOIlqOLmdiUYpAQ0mYfgVT/GDm8GOYhgi4GL+hMKrkiPRohO4ts34ELFsGAPQLDQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-function-name": {
@@ -188,6 +373,17 @@
       "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
       "dev": true
     },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz",
+      "integrity": "sha512-rLQKdQU+HYlxBwQIj8dk4/0ENOUEhA/Z0l4hN8BexpvmSMN9oA9EagjnhnDpNsRdWCfjwa4mn/HyBXO9yhQP6A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-wrap-function": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      }
+    },
     "@babel/helper-replace-supers": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
@@ -204,6 +400,15 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
       "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
+      "integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
@@ -229,6 +434,18 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
       "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
       "dev": true
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.14.5.tgz",
+      "integrity": "sha512-YEdjTCq+LNuNS1WfxsDCNpgXkJaIyqco6DAelTUjT4f2KIWC1nBcaCaSdHTBqQVLnTBexBcVcFhLSU1KnYuePQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      }
     },
     "@babel/helpers": {
       "version": "7.14.6",
@@ -258,6 +475,175 @@
       "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
       "dev": true
     },
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.14.5.tgz",
+      "integrity": "sha512-ZoJS2XCKPBfTmL122iP6NM9dOg+d4lc9fFk3zxc8iDjvt8Pk4+TlsHSKhIPf6X+L5ORCdBzqMZDjL/WHj7WknQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+        "@babel/plugin-proposal-optional-chaining": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.9.tgz",
+      "integrity": "sha512-d1lnh+ZnKrFKwtTYdw320+sQWCTwgkB9fmUhNXRADA4akR6wLjaruSGnIEUjpt9HCOwTr4ynFTKu19b7rFRpmw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-remap-async-to-generator": "^7.14.5",
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+      "integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-KBAH5ksEnYHCegqseI5N9skTdxgJdmDoAOc0uXa+4QMYKeZD0w5IARh4FMlTNtaHhbB8v+KzMdTgxMMzsIy6Yg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.5.tgz",
+      "integrity": "sha512-ExjiNYc3HDN5PXJx+bwC50GIx/KKanX2HiggnIUAYedbARdImiCU4RhhHfdf0Kd7JNXGpsBBBCOm+bBVy3Gb0g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.5.tgz",
+      "integrity": "sha512-g5POA32bXPMmSBu5Dx/iZGLGnKmKPc5AiY7qfZgurzrCYgIztDlHFbznSNCoQuv57YQLnQfaDi7dxCtLDIdXdA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.14.5.tgz",
+      "integrity": "sha512-NSq2fczJYKVRIsUJyNxrVUMhB27zb7N7pOFGQOhBKJrChbGcgEAqyZrmZswkPk18VMurEeJAaICbfm57vUeTbQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-logical-assignment-operators": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.14.5.tgz",
+      "integrity": "sha512-YGn2AvZAo9TwyhlLvCCWxD90Xq8xJ4aSgaX3G5D/8DW94L8aaT+dS5cSP+Z06+rCJERGSr9GxMBZ601xoc2taw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
+      "integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-numeric-separator": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.5.tgz",
+      "integrity": "sha512-yiclALKe0vyZRZE0pS6RXgjUOt87GWv6FYa5zqj15PvhOGFO69R5DusPlgK/1K5dVnCtegTiWu9UaBSrLLJJBg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
+      "integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.14.7",
+        "@babel/helper-compilation-targets": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.14.5.tgz",
+      "integrity": "sha512-3Oyiixm0ur7bzO5ybNcZFlmVsygSIQgdOa7cTfOYCMY+wEPAYhZAJxi3mixKFCTCKUhQXuCTtQ1MzrpL3WT8ZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
+      "integrity": "sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-private-methods": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.14.5.tgz",
+      "integrity": "sha512-838DkdUA1u+QTCplatfq4B7+1lnDa/+QMI89x5WZHBcnNv+47N8QEj2k9I2MUU9xIv8XJ4XvPCviM/Dj7Uwt9g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-62EyfyA3WA0mZiF2e2IV9mc9Ghwxcg8YTu8BS4Wss4Y3PY725OmS9M0qLORbJwLqFtGh+jiE4wAmocK2CTUK2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.14.5.tgz",
+      "integrity": "sha512-6axIeOU5LnY471KenAB9vI8I5j7NQ2d652hIYwVyRfgaZT5UpiqFKCuVXCDMSrU+3VFafnu2c5m3lrWIlr6A5Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -285,6 +671,42 @@
         "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
+    "@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
+      "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -301,6 +723,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -357,6 +788,15 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
     "@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
@@ -373,6 +813,701 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
+      "integrity": "sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.14.5.tgz",
+      "integrity": "sha512-szkbzQ0mNk0rpu76fzDdqSyPu0MuvpXgC+6rz5rpMb5OIRxdmHfQxrktL8CYolL2d8luMCZTR0DpIMIdL27IjA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-remap-async-to-generator": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.14.5.tgz",
+      "integrity": "sha512-dtqWqdWZ5NqBX3KzsVCWfQI3A53Ft5pWFCT2eCVUftWZgjc5DpDponbIF1+c+7cSGk2wN0YK7HGL/ezfRbpKBQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.15.3.tgz",
+      "integrity": "sha512-nBAzfZwZb4DkaGtOes1Up1nOAp9TDRRFw4XBzBBSG9QK7KVFmYzgj9o9sbPv7TX5ofL4Auq4wZnxCoPnI/lz2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.9.tgz",
+      "integrity": "sha512-NfZpTcxU3foGWbl4wxmZ35mTsYJy8oQocbeIMoDAGGFarAmSQlL+LWMkDx/tj6pNotpbX3rltIA4dprgAPOq5A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.14.5.tgz",
+      "integrity": "sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+      "integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.14.5.tgz",
+      "integrity": "sha512-loGlnBdj02MDsFaHhAIJzh7euK89lBrGIdM9EAtHFo6xKygCUGuuWe07o1oZVk287amtW1n0808sQM99aZt3gw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.14.5.tgz",
+      "integrity": "sha512-iJjbI53huKbPDAsJ8EmVmvCKeeq21bAze4fu9GBQtSLqfvzj2oRuHVx4ZkDwEhg1htQ+5OBZh/Ab0XDf5iBZ7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.14.5.tgz",
+      "integrity": "sha512-jFazJhMBc9D27o9jDnIE5ZErI0R0m7PbKXVq77FFvqFbzvTMuv8jaAwLZ5PviOLSFttqKIW0/wxNSDbjLk0tYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
+      "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-flow": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.14.5.tgz",
+      "integrity": "sha512-CfmqxSUZzBl0rSjpoQSFoR9UEj3HzbGuGNL21/iFTmjb5gFggJp3ph0xR1YBhexmLoKRHzgxuFvty2xdSt6gTA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.14.5.tgz",
+      "integrity": "sha512-vbO6kv0fIzZ1GpmGQuvbwwm+O4Cbm2NrPzwlup9+/3fdkuzo1YqOZcXw26+YUJB84Ja7j9yURWposEHLYwxUfQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.14.5.tgz",
+      "integrity": "sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.14.5.tgz",
+      "integrity": "sha512-WkNXxH1VXVTKarWFqmso83xl+2V3Eo28YY5utIkbsmXoItO8Q3aZxN4BTS2k0hz9dGUloHK26mJMyQEYfkn/+Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.5.tgz",
+      "integrity": "sha512-3lpOU8Vxmp3roC4vzFpSdEpGUWSMsHFreTWOMMLzel2gNGfHE5UWIh/LN6ghHs2xurUp4jRFYMUIZhuFbody1g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.0.tgz",
+      "integrity": "sha512-3H/R9s8cXcOGE8kgMlmjYYC9nqr5ELiPkJn4q0mypBrjhYQoc+5/Maq69vV4xRPWnkzZuwJPf5rArxpB/35Cig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.15.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-simple-access": "^7.14.8",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+          "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
+          "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.14.5",
+            "@babel/helper-replace-supers": "^7.15.0",
+            "@babel/helper-simple-access": "^7.14.8",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "@babel/template": "^7.14.5",
+            "@babel/traverse": "^7.15.0",
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+          "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.15.0",
+            "@babel/helper-optimise-call-expression": "^7.14.5",
+            "@babel/traverse": "^7.15.0",
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+          "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.8"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.0",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.14.5.tgz",
+      "integrity": "sha512-mNMQdvBEE5DcMQaL5LbzXFMANrQjd2W7FPzg34Y4yEz7dBgdaC+9B84dSO+/1Wba98zoDbInctCDo4JGxz1VYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.14.5",
+        "@babel/helper-module-transforms": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.5.tgz",
+      "integrity": "sha512-RfPGoagSngC06LsGUYyM9QWSXZ8MysEjDJTAea1lqRjNECE3y0qIJF/qbvJxc4oA4s99HumIMdXOrd+TdKaAAA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.9.tgz",
+      "integrity": "sha512-l666wCVYO75mlAtGFfyFwnWmIXQm3kSH0C3IRnJqWcZbWkoihyAdDhFm2ZWaxWTqvBvhVFfJjMRQ0ez4oN1yYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.14.5.tgz",
+      "integrity": "sha512-Nx054zovz6IIRWEB49RDRuXGI4Gy0GMgqG0cII9L3MxqgXz/+rgII+RU58qpo4g7tNEx1jG7rRVH4ihZoP4esQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.14.5.tgz",
+      "integrity": "sha512-MKfOBWzK0pZIrav9z/hkRqIk/2bTv9qvxHzPQc12RcVkMOzpIKnFCNYJip00ssKWYkd8Sf5g0Wr7pqJ+cmtuFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
+      "integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.14.5.tgz",
+      "integrity": "sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
+      "integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+      "integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/types": "^7.14.9"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-react-jsx-development": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.14.5.tgz",
+      "integrity": "sha512-rdwG/9jC6QybWxVe2UVOa7q6cnTpw8JRRHOxntG/h6g/guAOe6AhtQHJuJh5FwmnXIT1bdm5vC2/5huV8ZOorQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-transform-react-jsx": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.14.5.tgz",
+      "integrity": "sha512-3X4HpBJimNxW4rhUy/SONPyNQHp5YRr0HhJdT2OH1BRp0of7u3Dkirc7x9FRJMKMqTBI079VZ1hzv7Ouuz///g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.14.5.tgz",
+      "integrity": "sha512-NVIY1W3ITDP5xQl50NgTKlZ0GrotKtLna08/uGY6ErQt6VEQZXla86x/CTddm5gZdcr+5GSsvMeTmWA5Ii6pkg==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.14.5.tgz",
+      "integrity": "sha512-cv4F2rv1nD4qdexOGsRQXJrOcyb5CrgjUH9PKrrtyhSDBNWGxd0UIitjyJiWagS+EbUGjG++22mGH1Pub8D6Vg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz",
+      "integrity": "sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
+      "integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.14.5.tgz",
+      "integrity": "sha512-Z7F7GyvEMzIIbwnziAZmnSNpdijdr4dWt+FJNBnBLz5mwDFkqIXU9wmBcWWad3QeJF5hMTkRe4dAq2sUZiG+8A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.14.5.tgz",
+      "integrity": "sha512-22btZeURqiepOfuy/VkFr+zStqlujWaarpMErvay7goJS6BWwdd6BY9zQyDLDa4x2S3VugxFb162IZ4m/S/+Gg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.14.5.tgz",
+      "integrity": "sha512-lXzLD30ffCWseTbMQzrvDWqljvZlHkXU+CnseMhkMNqU1sASnCsz3tSzAaH3vCUXb9PHeUb90ZT1BdFTm1xxJw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-escapes": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz",
+      "integrity": "sha512-crTo4jATEOjxj7bt9lbYXcBAM3LZaUrbP2uUdxb6WIorLmjNKSpHfIybgY4B8SRpbf8tEVIWH3Vtm7ayCrKocA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.14.5.tgz",
+      "integrity": "sha512-UygduJpC5kHeCiRw/xDVzC+wj8VaYSoKl5JNVmbP7MadpNinAm3SvZCxZ42H37KZBKztz46YC73i9yV34d0Tzw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.0.tgz",
+      "integrity": "sha512-FhEpCNFCcWW3iZLg0L2NPE9UerdtsCR6ZcsGHUX6Om6kbCQeL5QZDqFDmeNHC6/fy6UH3jEge7K4qG5uC9In0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
+        "@babel/plugin-proposal-async-generator-functions": "^7.14.9",
+        "@babel/plugin-proposal-class-properties": "^7.14.5",
+        "@babel/plugin-proposal-class-static-block": "^7.14.5",
+        "@babel/plugin-proposal-dynamic-import": "^7.14.5",
+        "@babel/plugin-proposal-export-namespace-from": "^7.14.5",
+        "@babel/plugin-proposal-json-strings": "^7.14.5",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
+        "@babel/plugin-proposal-numeric-separator": "^7.14.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
+        "@babel/plugin-proposal-optional-chaining": "^7.14.5",
+        "@babel/plugin-proposal-private-methods": "^7.14.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.14.5",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5",
+        "@babel/plugin-transform-arrow-functions": "^7.14.5",
+        "@babel/plugin-transform-async-to-generator": "^7.14.5",
+        "@babel/plugin-transform-block-scoped-functions": "^7.14.5",
+        "@babel/plugin-transform-block-scoping": "^7.14.5",
+        "@babel/plugin-transform-classes": "^7.14.9",
+        "@babel/plugin-transform-computed-properties": "^7.14.5",
+        "@babel/plugin-transform-destructuring": "^7.14.7",
+        "@babel/plugin-transform-dotall-regex": "^7.14.5",
+        "@babel/plugin-transform-duplicate-keys": "^7.14.5",
+        "@babel/plugin-transform-exponentiation-operator": "^7.14.5",
+        "@babel/plugin-transform-for-of": "^7.14.5",
+        "@babel/plugin-transform-function-name": "^7.14.5",
+        "@babel/plugin-transform-literals": "^7.14.5",
+        "@babel/plugin-transform-member-expression-literals": "^7.14.5",
+        "@babel/plugin-transform-modules-amd": "^7.14.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.15.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.14.5",
+        "@babel/plugin-transform-modules-umd": "^7.14.5",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
+        "@babel/plugin-transform-new-target": "^7.14.5",
+        "@babel/plugin-transform-object-super": "^7.14.5",
+        "@babel/plugin-transform-parameters": "^7.14.5",
+        "@babel/plugin-transform-property-literals": "^7.14.5",
+        "@babel/plugin-transform-regenerator": "^7.14.5",
+        "@babel/plugin-transform-reserved-words": "^7.14.5",
+        "@babel/plugin-transform-shorthand-properties": "^7.14.5",
+        "@babel/plugin-transform-spread": "^7.14.6",
+        "@babel/plugin-transform-sticky-regex": "^7.14.5",
+        "@babel/plugin-transform-template-literals": "^7.14.5",
+        "@babel/plugin-transform-typeof-symbol": "^7.14.5",
+        "@babel/plugin-transform-unicode-escapes": "^7.14.5",
+        "@babel/plugin-transform-unicode-regex": "^7.14.5",
+        "@babel/preset-modules": "^0.1.4",
+        "@babel/types": "^7.15.0",
+        "babel-plugin-polyfill-corejs2": "^0.2.2",
+        "babel-plugin-polyfill-corejs3": "^0.2.2",
+        "babel-plugin-polyfill-regenerator": "^0.2.2",
+        "core-js-compat": "^3.16.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "@babel/compat-data": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+          "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+          "dev": true
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
+          "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.15.0",
+            "@babel/helper-validator-option": "^7.14.5",
+            "browserslist": "^4.16.6",
+            "semver": "^6.3.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/plugin-proposal-class-properties": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+          "integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.14.5",
+            "@babel/helper-plugin-utils": "^7.14.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/preset-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.14.5.tgz",
+      "integrity": "sha512-pP5QEb4qRUSVGzzKx9xqRuHUrM/jEzMqdrZpdMA+oUCRgd5zM1qGr5y5+ZgAL/1tVv1H0dyk5t4SKJntqyiVtg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-flow-strip-types": "^7.14.5"
+      }
+    },
+    "@babel/preset-modules": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+      "integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
+    "@babel/preset-react": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.14.5.tgz",
+      "integrity": "sha512-XFxBkjyObLvBaAvkx1Ie95Iaq4S/GUEIrejyrntQ/VCMKUYvKLoyKxOBzJ2kjA3b6rC9/KL6KXfDC2GqvLiNqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-react-display-name": "^7.14.5",
+        "@babel/plugin-transform-react-jsx": "^7.14.5",
+        "@babel/plugin-transform-react-jsx-development": "^7.14.5",
+        "@babel/plugin-transform-react-pure-annotations": "^7.14.5"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -1069,6 +2204,130 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/plugin-alias": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.5.tgz",
+      "integrity": "sha512-yzUaSvCC/LJPbl9rnzX3HN7vy0tq7EzHoEiQl1ofh4n5r2Rd5bj/+zcJgaGA76xbw95/JjWQyvHg9rOJp2y0oQ==",
+      "dev": true,
+      "requires": {
+        "slash": "^3.0.0"
+      }
+    },
+    "@rollup/plugin-babel": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
+      "integrity": "sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@rollup/pluginutils": "^3.1.0"
+      }
+    },
+    "@rollup/plugin-commonjs": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-17.1.0.tgz",
+      "integrity": "sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz",
+      "integrity": "sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      },
+      "dependencies": {
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1091,6 +2350,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@trysound/sax": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
+      "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==",
       "dev": true
     },
     "@types/babel__core": {
@@ -1133,6 +2398,12 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "@types/geojson": {
       "version": "7946.0.7",
@@ -1311,11 +2582,26 @@
       "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
       "dev": true
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
       "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
       "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.0",
@@ -1598,6 +2884,12 @@
         "repeat-string": "^1.5.2"
       }
     },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -1720,6 +3012,65 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "asyncro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/asyncro/-/asyncro-3.0.0.tgz",
+      "integrity": "sha512-nEnWYfrBmA3taTiuiOoZYmgJ/CNrSoQLeLs29SeLcPu60yaw/mHDBHV0iOZ051fTvsTHxpCY+gXibqT9wbQYfg==",
+      "dev": true
+    },
+    "autoprefixer": {
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.3.tgz",
+      "integrity": "sha512-yRzjxfnggrP/+qVHlUuZz5FZzEbkT+Yt0/Df6ScEMnbbZBLzYB2W0KLxoQCW+THm1SpOsM1ZPcTHAwuvmibIsQ==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.16.8",
+        "caniuse-lite": "^1.0.30001252",
+        "colorette": "^1.3.0",
+        "fraction.js": "^4.1.1",
+        "normalize-range": "^0.1.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.16.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+          "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001251",
+            "colorette": "^1.3.0",
+            "electron-to-chromium": "^1.3.811",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.75"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001252",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+          "dev": true
+        },
+        "colorette": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+          "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.827",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.827.tgz",
+          "integrity": "sha512-ye+4uQOY/jbjRutMcE/EmOcNwUeo1qo9aKL2tPyb09cU3lmxNeyDF4RWiemmkknW+p29h7dyDqy02higTxc9/A==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.75",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+          "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+          "dev": true
+        }
+      }
+    },
     "available-typed-arrays": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
@@ -1804,6 +3155,15 @@
         }
       }
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -1827,6 +3187,80 @@
         "@babel/types": "^7.3.3",
         "@types/babel__core": "^7.0.0",
         "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "dependencies": {
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "babel-plugin-polyfill-corejs2": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+      "integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.13.11",
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
+        "semver": "^6.1.1"
+      }
+    },
+    "babel-plugin-polyfill-corejs3": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
+      "integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
+        "core-js-compat": "^3.14.0"
+      }
+    },
+    "babel-plugin-polyfill-regenerator": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+      "integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.2.2"
+      }
+    },
+    "babel-plugin-transform-async-to-promises": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz",
+      "integrity": "sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==",
+      "dev": true
+    },
+    "babel-plugin-transform-replace-expressions": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-replace-expressions/-/babel-plugin-transform-replace-expressions-0.2.0.tgz",
+      "integrity": "sha512-Eh1rRd9hWEYgkgoA3D0kGp7xJ/wgVshgsqmq60iC4HVWD+Lux+fNHSHBa2v1Hsv+dHflShC71qKhiH40OiPtDA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.3.3"
       }
     },
     "babel-preset-current-node-syntax": {
@@ -1871,6 +3305,12 @@
       "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
       "dev": true
     },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1881,6 +3321,12 @@
       "version": "4.11.7",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
       "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA==",
+      "dev": true
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
     "brace-expansion": {
@@ -1907,6 +3353,15 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
+    },
+    "brotli-size": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/brotli-size/-/brotli-size-4.0.0.tgz",
+      "integrity": "sha512-uA9fOtlTRC0iqKfzff1W34DXUA3GyVqbUaeo3Rw3d4gd1eavKVCETXrn3NzO74W+UVkG3UHu8WxUi+XvKI/huA==",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
     },
     "browser-pack": {
       "version": "6.0.2",
@@ -2121,6 +3576,12 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true
+    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -2162,6 +3623,26 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true
+    },
+    "caniuse-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      },
+      "dependencies": {
+        "lodash.memoize": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+          "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+          "dev": true
+        }
+      }
     },
     "caniuse-lite": {
       "version": "1.0.30001239",
@@ -2300,6 +3781,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colord": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.7.0.tgz",
+      "integrity": "sha512-pZJBqsHz+pYyw3zpX6ZRXWoCHM1/cvFikY9TV8G3zcejCaKE0lhankoj8iScyrrePA8C7yJ5FStfA9zbcOnw7Q==",
+      "dev": true
+    },
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -2326,6 +3813,18 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2360,6 +3859,23 @@
         }
       }
     },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -2381,11 +3897,93 @@
       "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
       "dev": true
     },
+    "core-js-compat": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.1.tgz",
+      "integrity": "sha512-Oqp6qybMdCFcWSroh/6Q8j7YNOjRD0ThY02cAd6rugr//FCkMYonizLV8AryLU5wNJOweauIBxQYCZoV3emfcw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.16.8",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.16.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+          "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001251",
+            "colorette": "^1.3.0",
+            "electron-to-chromium": "^1.3.811",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.75"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001252",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+          "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+          "dev": true
+        },
+        "colorette": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+          "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.827",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.827.tgz",
+          "integrity": "sha512-ye+4uQOY/jbjRutMcE/EmOcNwUeo1qo9aKL2tPyb09cU3lmxNeyDF4RWiemmkknW+p29h7dyDqy02higTxc9/A==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.75",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+          "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "dev": true
+        }
+      }
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        }
+      }
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -2460,6 +4058,128 @@
         "pbkdf2": "^3.0.3",
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0"
+      }
+    },
+    "css-color-names": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-1.0.1.tgz",
+      "integrity": "sha512-/loXYOch1qU1biStIFsHH8SxTmOseh1IJqFvy8IujXOm1h+QjUdDhkzOrR5HG8K8mlxREj0yfi8ewCHx0eMxzA==",
+      "dev": true
+    },
+    "css-declaration-sorter": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.1.tgz",
+      "integrity": "sha512-BZ1aOuif2Sb7tQYY1GeCjG7F++8ggnwUkH5Ictw0mrdpqpEd+zWmcPdstnH2TItlb74FqR0DrVEieon221T/1Q==",
+      "dev": true,
+      "requires": {
+        "timsort": "^0.3.0"
+      }
+    },
+    "css-select": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+      "dev": true,
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^5.0.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.6.0",
+        "nth-check": "^2.0.0"
+      }
+    },
+    "css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dev": true,
+      "requires": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "css-what": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
+    },
+    "cssnano": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.8.tgz",
+      "integrity": "sha512-Lda7geZU0Yu+RZi2SGpjYuQz4HI4/1Y+BhdD0jL7NXAQ5larCzVn+PUGuZbDMYz904AXXCOgO5L1teSvgu7aFg==",
+      "dev": true,
+      "requires": {
+        "cssnano-preset-default": "^5.1.4",
+        "is-resolvable": "^1.1.0",
+        "lilconfig": "^2.0.3",
+        "yaml": "^1.10.2"
+      }
+    },
+    "cssnano-preset-default": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.4.tgz",
+      "integrity": "sha512-sPpQNDQBI3R/QsYxQvfB4mXeEcWuw0wGtKtmS5eg8wudyStYMgKOQT39G07EbW1LB56AOYrinRS9f0ig4Y3MhQ==",
+      "dev": true,
+      "requires": {
+        "css-declaration-sorter": "^6.0.3",
+        "cssnano-utils": "^2.0.1",
+        "postcss-calc": "^8.0.0",
+        "postcss-colormin": "^5.2.0",
+        "postcss-convert-values": "^5.0.1",
+        "postcss-discard-comments": "^5.0.1",
+        "postcss-discard-duplicates": "^5.0.1",
+        "postcss-discard-empty": "^5.0.1",
+        "postcss-discard-overridden": "^5.0.1",
+        "postcss-merge-longhand": "^5.0.2",
+        "postcss-merge-rules": "^5.0.2",
+        "postcss-minify-font-values": "^5.0.1",
+        "postcss-minify-gradients": "^5.0.2",
+        "postcss-minify-params": "^5.0.1",
+        "postcss-minify-selectors": "^5.1.0",
+        "postcss-normalize-charset": "^5.0.1",
+        "postcss-normalize-display-values": "^5.0.1",
+        "postcss-normalize-positions": "^5.0.1",
+        "postcss-normalize-repeat-style": "^5.0.1",
+        "postcss-normalize-string": "^5.0.1",
+        "postcss-normalize-timing-functions": "^5.0.1",
+        "postcss-normalize-unicode": "^5.0.1",
+        "postcss-normalize-url": "^5.0.2",
+        "postcss-normalize-whitespace": "^5.0.1",
+        "postcss-ordered-values": "^5.0.2",
+        "postcss-reduce-initial": "^5.0.1",
+        "postcss-reduce-transforms": "^5.0.1",
+        "postcss-svgo": "^5.0.2",
+        "postcss-unique-selectors": "^5.0.1"
+      }
+    },
+    "cssnano-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
+      "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
+      "dev": true
+    },
+    "csso": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "dev": true,
+      "requires": {
+        "css-tree": "^1.1.2"
       }
     },
     "cssom": {
@@ -2641,10 +4361,27 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      }
+    },
     "domain-browser": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "dev": true
+    },
+    "domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
       "dev": true
     },
     "domexception": {
@@ -2663,6 +4400,32 @@
           "dev": true
         }
       }
+    },
+    "domhandler": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      }
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -2724,6 +4487,18 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true
     },
     "error-ex": {
@@ -2960,10 +4735,22 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "events": {
@@ -3199,6 +4986,12 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "filesize": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
+      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==",
+      "dev": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3206,6 +4999,17 @@
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
       }
     },
     "find-up": {
@@ -3261,6 +5065,23 @@
         "samsam": "~1.1"
       }
     },
+    "fraction.js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
+      "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3285,6 +5106,15 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "generic-names": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
+      "integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0"
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -3375,6 +5205,12 @@
         "type-fest": "^0.8.1"
       }
     },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
     "globby": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
@@ -3397,11 +5233,34 @@
         }
       }
     },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
+    },
+    "gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.2"
+      },
+      "dependencies": {
+        "duplexer": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+          "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+          "dev": true
+        }
+      }
     },
     "has": {
       "version": "1.0.1",
@@ -3410,6 +5269,23 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.0.2"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -3523,6 +5399,18 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true
+    },
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
@@ -3535,6 +5423,15 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "import-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+      "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+      "dev": true,
+      "requires": {
+        "import-from": "^3.0.0"
+      }
+    },
     "import-fresh": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
@@ -3543,6 +5440,23 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      }
+    },
+    "import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
       }
     },
     "import-local": {
@@ -3689,6 +5603,12 @@
         "xtend": "^4.0.0"
       }
     },
+    "is-absolute-url": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+      "dev": true
+    },
     "is-arguments": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
@@ -3799,6 +5719,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -3817,6 +5743,15 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
     "is-regex": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
@@ -3826,6 +5761,12 @@
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-stream": {
       "version": "2.0.0",
@@ -5473,6 +7414,12 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5501,6 +7448,15 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -5585,6 +7541,18 @@
         "astw": "^2.0.0"
       }
     },
+    "lilconfig": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
+      "integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+      "dev": true
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -5605,6 +7573,28 @@
         }
       }
     },
+    "loader-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -5620,10 +7610,34 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
     "lolex": {
@@ -5645,6 +7659,15 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -5671,6 +7694,94 @@
         "tmpl": "1.0.x"
       }
     },
+    "maxmin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-2.1.0.tgz",
+      "integrity": "sha1-TTsiCQPZXu5+t6x/qGTnLcCaMWY=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "figures": "^1.0.1",
+        "gzip-size": "^3.0.0",
+        "pretty-bytes": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "gzip-size": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+          "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+          "dev": true,
+          "requires": {
+            "duplexer": "^0.1.1"
+          }
+        },
+        "pretty-bytes": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+          "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "dev": true
+    },
     "memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -5688,6 +7799,86 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
+    },
+    "microbundle": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/microbundle/-/microbundle-0.13.3.tgz",
+      "integrity": "sha512-nlP20UmyqGGeh6jhk8VaVFEoRlF+JAvnwixPLQUwHEcAF59ROJCyh34eylJzUAVNvF3yrCaHxIBv8lYcphDM1g==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.12.10",
+        "@babel/plugin-proposal-class-properties": "7.12.1",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-jsx": "^7.12.1",
+        "@babel/plugin-transform-flow-strip-types": "^7.12.10",
+        "@babel/plugin-transform-react-jsx": "^7.12.11",
+        "@babel/plugin-transform-regenerator": "^7.12.1",
+        "@babel/preset-env": "^7.12.11",
+        "@babel/preset-flow": "^7.12.1",
+        "@babel/preset-react": "^7.12.10",
+        "@rollup/plugin-alias": "^3.1.1",
+        "@rollup/plugin-babel": "^5.2.2",
+        "@rollup/plugin-commonjs": "^17.0.0",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^11.0.1",
+        "asyncro": "^3.0.0",
+        "autoprefixer": "^10.1.0",
+        "babel-plugin-macros": "^3.0.1",
+        "babel-plugin-transform-async-to-promises": "^0.8.15",
+        "babel-plugin-transform-replace-expressions": "^0.2.0",
+        "brotli-size": "^4.0.0",
+        "builtin-modules": "^3.1.0",
+        "camelcase": "^6.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "filesize": "^6.1.0",
+        "gzip-size": "^6.0.0",
+        "kleur": "^4.1.3",
+        "lodash.merge": "^4.6.2",
+        "postcss": "^8.2.1",
+        "pretty-bytes": "^5.4.1",
+        "rollup": "^2.35.1",
+        "rollup-plugin-bundle-size": "^1.0.3",
+        "rollup-plugin-postcss": "^4.0.0",
+        "rollup-plugin-terser": "^7.0.2",
+        "rollup-plugin-typescript2": "^0.29.0",
+        "sade": "^1.7.4",
+        "terser": "^5.7.0",
+        "tiny-glob": "^0.2.8",
+        "tslib": "^2.0.3",
+        "typescript": "^4.1.3"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "kleur": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+          "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+          "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+          "dev": true
+        }
+      }
     },
     "micromatch": {
       "version": "4.0.4",
@@ -5811,6 +8002,12 @@
         "xtend": "^4.0.0"
       }
     },
+    "mri": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5821,6 +8018,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "natural-compare": {
@@ -5895,6 +8098,18 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true
+    },
     "npm-run-all": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
@@ -5928,6 +8143,21 @@
           "dev": true
         }
       }
+    },
+    "nth-check": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "dev": true,
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -6024,6 +8254,12 @@
       "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -6040,6 +8276,25 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
+      }
+    },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -6192,10 +8447,362 @@
         "find-up": "^4.0.0"
       }
     },
+    "postcss": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "dev": true,
+      "requires": {
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
+      }
+    },
+    "postcss-calc": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.0.0.tgz",
+      "integrity": "sha512-5NglwDrcbiy8XXfPM11F3HeC6hoT9W7GUH/Zi5U/p7u3Irv4rHhdDcIZwG0llHXV4ftsBjpfWMXAnXNl4lnt8g==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "postcss-colormin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.2.0.tgz",
+      "integrity": "sha512-+HC6GfWU3upe5/mqmxuqYZ9B2Wl4lcoUUNkoaX59nEWV4EtADCMiBqui111Bu8R8IvaZTmqmxrqOAqjbHIwXPw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.16.6",
+        "caniuse-api": "^3.0.0",
+        "colord": "^2.0.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-convert-values": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.0.1.tgz",
+      "integrity": "sha512-C3zR1Do2BkKkCgC0g3sF8TS0koF2G+mN8xxayZx3f10cIRmTaAnpgpRQZjNekTZxM2ciSPoh2IWJm0VZx8NoQg==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
+      "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
+      "dev": true
+    },
+    "postcss-discard-duplicates": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
+      "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
+      "dev": true
+    },
+    "postcss-discard-empty": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
+      "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
+      "dev": true
+    },
+    "postcss-discard-overridden": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
+      "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
+      "dev": true
+    },
+    "postcss-load-config": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.0.tgz",
+      "integrity": "sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==",
+      "dev": true,
+      "requires": {
+        "import-cwd": "^3.0.0",
+        "lilconfig": "^2.0.3",
+        "yaml": "^1.10.2"
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.0.2.tgz",
+      "integrity": "sha512-BMlg9AXSI5G9TBT0Lo/H3PfUy63P84rVz3BjCFE9e9Y9RXQZD3+h3YO1kgTNsNJy7bBc1YQp8DmSnwLIW5VPcw==",
+      "dev": true,
+      "requires": {
+        "css-color-names": "^1.0.1",
+        "postcss-value-parser": "^4.1.0",
+        "stylehacks": "^5.0.1"
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.0.2.tgz",
+      "integrity": "sha512-5K+Md7S3GwBewfB4rjDeol6V/RZ8S+v4B66Zk2gChRqLTCC8yjnHQ601omj9TKftS19OPGqZ/XzoqpzNQQLwbg==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.16.6",
+        "caniuse-api": "^3.0.0",
+        "cssnano-utils": "^2.0.1",
+        "postcss-selector-parser": "^6.0.5",
+        "vendors": "^1.0.3"
+      }
+    },
+    "postcss-minify-font-values": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.0.1.tgz",
+      "integrity": "sha512-7JS4qIsnqaxk+FXY1E8dHBDmraYFWmuL6cgt0T1SWGRO5bzJf8sUoelwa4P88LEWJZweHevAiDKxHlofuvtIoA==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.2.tgz",
+      "integrity": "sha512-7Do9JP+wqSD6Prittitt2zDLrfzP9pqKs2EcLX7HJYxsxCOwrrcLt4x/ctQTsiOw+/8HYotAoqNkrzItL19SdQ==",
+      "dev": true,
+      "requires": {
+        "colord": "^2.6",
+        "cssnano-utils": "^2.0.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-minify-params": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.0.1.tgz",
+      "integrity": "sha512-4RUC4k2A/Q9mGco1Z8ODc7h+A0z7L7X2ypO1B6V8057eVK6mZ6xwz6QN64nHuHLbqbclkX1wyzRnIrdZehTEHw==",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.2",
+        "browserslist": "^4.16.0",
+        "cssnano-utils": "^2.0.1",
+        "postcss-value-parser": "^4.1.0",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.1.0.tgz",
+      "integrity": "sha512-NzGBXDa7aPsAcijXZeagnJBKBPMYLaJJzB8CQh6ncvyl2sIndLVWfbcDi0SBjRWk5VqEjXvf8tYwzoKf4Z07og==",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.2",
+        "postcss-selector-parser": "^6.0.5"
+      }
+    },
+    "postcss-modules": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.2.2.tgz",
+      "integrity": "sha512-/H08MGEmaalv/OU8j6bUKi/kZr2kqGF6huAW8m9UAgOLWtpFdhA14+gPBoymtqyv+D4MLsmqaF2zvIegdCxJXg==",
+      "dev": true,
+      "requires": {
+        "generic-names": "^2.0.1",
+        "icss-replace-symbols": "^1.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.0",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "string-hash": "^1.1.1"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "dev": true
+    },
+    "postcss-modules-local-by-default": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.0.4"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.0.0"
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
+      "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
+      "dev": true
+    },
+    "postcss-normalize-display-values": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.1.tgz",
+      "integrity": "sha512-uupdvWk88kLDXi5HEyI9IaAJTE3/Djbcrqq8YgjvAVuzgVuqIk3SuJWUisT2gaJbZm1H9g5k2w1xXilM3x8DjQ==",
+      "dev": true,
+      "requires": {
+        "cssnano-utils": "^2.0.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-normalize-positions": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.0.1.tgz",
+      "integrity": "sha512-rvzWAJai5xej9yWqlCb1OWLd9JjW2Ex2BCPzUJrbaXmtKtgfL8dBMOOMTX6TnvQMtjk3ei1Lswcs78qKO1Skrg==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-normalize-repeat-style": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.1.tgz",
+      "integrity": "sha512-syZ2itq0HTQjj4QtXZOeefomckiV5TaUO6ReIEabCh3wgDs4Mr01pkif0MeVwKyU/LHEkPJnpwFKRxqWA/7O3w==",
+      "dev": true,
+      "requires": {
+        "cssnano-utils": "^2.0.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-normalize-string": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.0.1.tgz",
+      "integrity": "sha512-Ic8GaQ3jPMVl1OEn2U//2pm93AXUcF3wz+OriskdZ1AOuYV25OdgS7w9Xu2LO5cGyhHCgn8dMXh9bO7vi3i9pA==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-normalize-timing-functions": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.1.tgz",
+      "integrity": "sha512-cPcBdVN5OsWCNEo5hiXfLUnXfTGtSFiBU9SK8k7ii8UD7OLuznzgNRYkLZow11BkQiiqMcgPyh4ZqXEEUrtQ1Q==",
+      "dev": true,
+      "requires": {
+        "cssnano-utils": "^2.0.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-normalize-unicode": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.1.tgz",
+      "integrity": "sha512-kAtYD6V3pK0beqrU90gpCQB7g6AOfP/2KIPCVBKJM2EheVsBQmx/Iof+9zR9NFKLAx4Pr9mDhogB27pmn354nA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.16.0",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.2.tgz",
+      "integrity": "sha512-k4jLTPUxREQ5bpajFQZpx8bCF2UrlqOTzP9kEqcEnOfwsRshWs2+oAFIHfDQB8GO2PaUaSE0NlTAYtbluZTlHQ==",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "^3.0.3",
+        "normalize-url": "^6.0.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-normalize-whitespace": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.1.tgz",
+      "integrity": "sha512-iPklmI5SBnRvwceb/XH568yyzK0qRVuAG+a1HFUsFRf11lEJTiQQa03a4RSCQvLKdcpX7XsI1Gen9LuLoqwiqA==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.2.tgz",
+      "integrity": "sha512-8AFYDSOYWebJYLyJi3fyjl6CqMEG/UVworjiyK1r573I56kb3e879sCJLGvR3merj+fAdPpVplXKQZv+ey6CgQ==",
+      "dev": true,
+      "requires": {
+        "cssnano-utils": "^2.0.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.0.1.tgz",
+      "integrity": "sha512-zlCZPKLLTMAqA3ZWH57HlbCjkD55LX9dsRyxlls+wfuRfqCi5mSlZVan0heX5cHr154Dq9AfbH70LyhrSAezJw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.16.0",
+        "caniuse-api": "^3.0.0"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.1.tgz",
+      "integrity": "sha512-a//FjoPeFkRuAguPscTVmRQUODP+f3ke2HqFNgGPwdYnpeC29RZdCBvGRGTsKpMURb/I3p6jdKoBQ2zI+9Q7kA==",
+      "dev": true,
+      "requires": {
+        "cssnano-utils": "^2.0.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-svgo": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.0.2.tgz",
+      "integrity": "sha512-YzQuFLZu3U3aheizD+B1joQ94vzPfE6BNUcSYuceNxlVnKKsOtdo6hL9/zyC168Q8EwfLSgaDSalsUGa9f2C0A==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.1.0",
+        "svgo": "^2.3.0"
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.0.1.tgz",
+      "integrity": "sha512-gwi1NhHV4FMmPn+qwBNuot1sG1t2OmacLQ/AX29lzyggnjd+MnVD5uqQmpXO3J17KGL2WAxQruj1qTd3H0gG/w==",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.2",
+        "postcss-selector-parser": "^6.0.5",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
       "dev": true
     },
     "pretty-format": {
@@ -6234,6 +8841,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "promise.series": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
+      "integrity": "sha1-LMfr6Vn8OmYZwEq029yeRS2GS70=",
       "dev": true
     },
     "prompts": {
@@ -6364,11 +8977,78 @@
         "picomatch": "^2.2.1"
       }
     },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+      "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "regexpu-core": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+      "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.2.0",
+        "regjsgen": "^0.5.1",
+        "regjsparser": "^0.6.4",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.2.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.9.tgz",
+      "integrity": "sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -6474,6 +9154,254 @@
         "inherits": "^2.0.1"
       }
     },
+    "rollup": {
+      "version": "2.56.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
+      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-bundle-size": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-bundle-size/-/rollup-plugin-bundle-size-1.0.3.tgz",
+      "integrity": "sha512-aWj0Pvzq90fqbI5vN1IvUrlf4utOqy+AERYxwWjegH1G8PzheMnrRIgQ5tkwKVtQMDP0bHZEACW/zLDF+XgfXQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "maxmin": "^2.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-postcss": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.1.tgz",
+      "integrity": "sha512-kUJHlpDGl9+kDfdUUbnerW0Mx1R0PL/6dgciUE/w19swYDBjug7RQfxIRvRGtO/cvCkynYyU8e/YFMI544vskA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "concat-with-sourcemaps": "^1.1.0",
+        "cssnano": "^5.0.1",
+        "import-cwd": "^3.0.0",
+        "p-queue": "^6.6.2",
+        "pify": "^5.0.0",
+        "postcss-load-config": "^3.0.0",
+        "postcss-modules": "^4.0.0",
+        "promise.series": "^0.2.0",
+        "resolve": "^1.19.0",
+        "rollup-pluginutils": "^2.8.2",
+        "safe-identifier": "^0.4.2",
+        "style-inject": "^0.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+          "dev": true
+        },
+        "pify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-worker": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+          "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "rollup-plugin-typescript2": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.29.0.tgz",
+      "integrity": "sha512-YytahBSZCIjn/elFugEGQR5qTsVhxhUwGZIsA9TmrSsC88qroGo65O5HZP/TTArH2dm0vUmYWhKchhwi2wL9bw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "8.1.0",
+        "resolve": "1.17.0",
+        "tslib": "2.0.1"
+      },
+      "dependencies": {
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+          "dev": true
+        }
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
+        }
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -6495,10 +9423,25 @@
         "tslib": "^1.9.0"
       }
     },
+    "sade": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
+      "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+      "dev": true,
+      "requires": {
+        "mri": "^1.1.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "safe-identifier": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
+      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
       "dev": true
     },
     "safer-buffer": {
@@ -6527,6 +9470,26 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      },
+      "dependencies": {
+        "randombytes": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+          "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.0"
+          }
+        }
+      }
     },
     "sha.js": {
       "version": "2.4.8",
@@ -6644,6 +9607,12 @@
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
       "dev": true
     },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true
+    },
     "source-map-support": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
@@ -6661,6 +9630,12 @@
           "dev": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -6698,6 +9673,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
     "stack-utils": {
@@ -6759,6 +9740,12 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.2"
       }
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+      "dev": true
     },
     "string-length": {
       "version": "4.0.2",
@@ -6875,6 +9862,22 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "style-inject": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
+      "integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==",
+      "dev": true
+    },
+    "stylehacks": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.0.1.tgz",
+      "integrity": "sha512-Es0rVnHIqbWzveU1b24kbw92HsebBepxfcqe5iix7t9j0PQqhs0IxXVXv0pY2Bxa08CgMkzD6OWql7kbGOuEdA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.16.0",
+        "postcss-selector-parser": "^6.0.4"
+      }
+    },
     "subarg": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
@@ -6917,6 +9920,29 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        }
+      }
+    },
+    "svgo": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.5.0.tgz",
+      "integrity": "sha512-FSdBOOo271VyF/qZnOn1PgwCdt1v4Dx0Sey+U1jgqm1vqRYjPGdip0RGrFW6ItwtkBB8rHgHk26dlVr0uCs82Q==",
+      "dev": true,
+      "requires": {
+        "@trysound/sax": "0.1.1",
+        "colorette": "^1.3.0",
+        "commander": "^7.2.0",
+        "css-select": "^4.1.3",
+        "css-tree": "^1.1.3",
+        "csso": "^4.2.0",
+        "stable": "^0.1.8"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+          "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+          "dev": true
         }
       }
     },
@@ -6982,6 +10008,31 @@
         "supports-hyperlinks": "^2.0.0"
       }
     },
+    "terser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
+      "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -7044,6 +10095,22 @@
       "dev": true,
       "requires": {
         "process": "~0.11.0"
+      }
+    },
+    "timsort": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "dev": true
+    },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
       }
     },
     "tmp": {
@@ -7253,6 +10320,40 @@
         "xtend": "^4.0.1"
       }
     },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
+      "dev": true
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+      "dev": true
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -7360,6 +10461,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vendors": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
+      "integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
+      "dev": true
     },
     "vm-browserify": {
       "version": "0.0.4",
@@ -8167,6 +11274,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -2,26 +2,39 @@
   "name": "wrld.js",
   "version": "0.0.1",
   "description": "A JavaScript API for beautiful 3D maps",
-  "main": "src/wrld.js",
+  "author": "WRLD",
+  "license": "See license in LICENSE.md",
+  "type": "module",
+
+  "source": "./src/wrld.js",
+  "exports": "./dist/wrld.modern.js",
+  "main": "./dist/wrld.cjs",
+  "module": "./dist/wrld.module.js",
+  "unpkg": "./dist/wrld.js",
+  "types": "types/index.d.ts",
+
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wrld3d/wrld.js.git"
+  },
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "npm run build-min",
-    "build-dist": "npm run clean && mkdir dist && browserify -s WRLD src/wrld.js > dist/wrld.js",
-    "build-min": "npm run build-dist && uglifyjs -c -m < dist/wrld.js > dist/wrld.min.js",
-    "watch": "npm run build-dist && watchify -s WRLD src/wrld.js -o dist/wrld.js -v --debug",
+    "build": "microbundle --generateTypes false --name WRLD",
+    "build-dist": "npm run build",
+    "build-min": "npm run build",
+    "watch": "microbundle watch",
+    "dev": "npm run watch",
     "lint": "eslint . --ext .js,.ts",
     "test": "run-s test:unit test:lint test:build",
     "test:build": "run-s build",
     "test:lint": "run-s lint",
     "test:interop": "sh -c './node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=tests/jasmine.json'",
-    "test:unit": "jest"
+    "test:unit": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
-  "author": "WRLD",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/wrld3d/wrld.js.git"
+  "dependencies": {
+    "@types/leaflet": "^1.0.69",
+    "leaflet": "1.0.1"
   },
-  "license": "See license in LICENSE.md",
   "devDependencies": {
     "@types/jest": "^26.0.23",
     "@types/node": "^12.20.15",
@@ -31,16 +44,12 @@
     "eslint": "^6.8.0",
     "jasmine": "~2.5.2",
     "jest": "^27.0.5",
+    "microbundle": "^0.13.3",
     "npm-run-all": "^4.1.5",
     "sinon": "~1.17.6",
     "ts-jest": "^27.0.3",
     "typescript": "^4.0.5",
     "uglify-js": "~2.6.0",
     "watchify": "^4.0.0"
-  },
-  "dependencies": {
-    "@types/leaflet": "^1.0.69",
-    "leaflet": "1.0.1"
-  },
-  "types": "types/index.d.ts"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,14 +5,12 @@
   "author": "WRLD",
   "license": "See license in LICENSE.md",
   "type": "module",
-
   "source": "./src/wrld.js",
   "exports": "./dist/wrld.modern.js",
   "main": "./dist/wrld.cjs",
   "module": "./dist/wrld.module.js",
   "unpkg": "./dist/wrld.js",
   "types": "types/index.d.ts",
-
   "repository": {
     "type": "git",
     "url": "https://github.com/wrld3d/wrld.js.git"
@@ -29,27 +27,29 @@
     "test:build": "run-s build",
     "test:lint": "run-s lint",
     "test:interop": "sh -c './node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=tests/jasmine.json'",
-    "test:unit": "NODE_OPTIONS=--experimental-vm-modules jest"
+    "test:unit": "jest"
   },
   "dependencies": {
     "@types/leaflet": "^1.0.69",
     "leaflet": "1.0.1"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.23",
+    "@babel/core": "^7.15.0",
+    "@babel/preset-env": "^7.15.0",
+    "@babel/preset-typescript": "^7.15.0",
+    "@types/jest": "^27.0.1",
     "@types/node": "^12.20.15",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
-    "browserify": "~13.0.0",
+    "babel-jest": "^27.1.0",
     "eslint": "^6.8.0",
     "jasmine": "~2.5.2",
-    "jest": "^27.0.5",
+    "jest": "^27.1.0",
     "microbundle": "^0.13.3",
     "npm-run-all": "^4.1.5",
     "sinon": "~1.17.6",
-    "ts-jest": "^27.0.3",
-    "typescript": "^4.0.5",
-    "uglify-js": "~2.6.0",
-    "watchify": "^4.0.0"
+    "ts-jest": "^27.0.5",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.5"
   }
 }

--- a/src/__tests__/public/indoorMapFloorOutlines/indoorMapFloorOutlines.test.ts
+++ b/src/__tests__/public/indoorMapFloorOutlines/indoorMapFloorOutlines.test.ts
@@ -1,4 +1,4 @@
-import indoorMapFloorOutlines from "../../../public/indoorMapFloorOutlines/indoorMapFloorOutlines";
+import { IndoorMapFloorOutlinePolygon, IndoorMapFloorOutlinePolygonRing, IndoorMapFloorOutlineInformation, indoorMapFloorOutlineInformation } from "../../../public/indoorMapFloorOutlines/indoorMapFloorOutlines";
 
 describe("indoorMapFloorOutlines namespace", () => {
 
@@ -6,7 +6,7 @@ describe("indoorMapFloorOutlines namespace", () => {
 
   describe("indoorMapFloorOutlines.IndoorMapFloorOutlinePolygon", () => {
     it("is a function", () => {
-      expect(typeof indoorMapFloorOutlines.IndoorMapFloorOutlinePolygon).toBe("function");
+      expect(typeof IndoorMapFloorOutlinePolygon).toBe("function");
     });
   });
 
@@ -14,7 +14,7 @@ describe("indoorMapFloorOutlines namespace", () => {
 
   describe("indoorMapFloorOutlines.IndoorMapFloorOutlinePolygonRing", () => {
     it("is a function", () => {
-      expect(typeof indoorMapFloorOutlines.IndoorMapFloorOutlinePolygonRing).toBe("function");
+      expect(typeof IndoorMapFloorOutlinePolygonRing).toBe("function");
     });
   });
 
@@ -22,7 +22,7 @@ describe("indoorMapFloorOutlines namespace", () => {
 
   describe("indoorMapFloorOutlines.IndoorMapFloorOutlineInformation", () => {
     it("is a function", () => {
-      expect(typeof indoorMapFloorOutlines.IndoorMapFloorOutlineInformation).toBe("function");
+      expect(typeof IndoorMapFloorOutlineInformation).toBe("function");
     });
   });
 
@@ -30,7 +30,7 @@ describe("indoorMapFloorOutlines namespace", () => {
 
   describe("indoorMapFloorOutlines.indoorMapFloorOutlineInformation", () => {
     it("is a function", () => {
-      expect(typeof indoorMapFloorOutlines.indoorMapFloorOutlineInformation).toBe("function");
+      expect(typeof indoorMapFloorOutlineInformation).toBe("function");
     });
   });
 });

--- a/src/__tests__/public/indoorMapFloorOutlines/indoor_map_floor_outline_information.test.ts
+++ b/src/__tests__/public/indoorMapFloorOutlines/indoor_map_floor_outline_information.test.ts
@@ -1,4 +1,4 @@
-import indoorMapFloorOutlines from "../../../../types/indoorMapFloorOutlines";
+import type indoorMapFloorOutlines from "../../../../types/indoorMapFloorOutlines";
 
 import { IndoorMapFloorOutlineInformation } from "../../../public/indoorMapFloorOutlines/indoor_map_floor_outline_information";
 

--- a/src/__tests__/public/indoors/indoors.test.ts
+++ b/src/__tests__/public/indoors/indoors.test.ts
@@ -1,4 +1,4 @@
-import indoors from "../../../public/indoors/indoors";
+import { IndoorMap, IndoorMapEntrance, IndoorMapFloor } from "../../../public/indoors/indoors";
 
 describe("indoors namespace", () => {
 
@@ -6,7 +6,7 @@ describe("indoors namespace", () => {
 
   describe("indoors.IndoorMap", () => {
     it("is a function", () => {
-      expect(typeof indoors.IndoorMap).toBe("function");
+      expect(typeof IndoorMap).toBe("function");
     });
   });
 
@@ -14,7 +14,7 @@ describe("indoors namespace", () => {
 
   describe("indoors.IndoorMapEntrance", () => {
     it("is a function", () => {
-      expect(typeof indoors.IndoorMapEntrance).toBe("function");
+      expect(typeof IndoorMapEntrance).toBe("function");
     });
   });
 
@@ -22,7 +22,7 @@ describe("indoors namespace", () => {
 
   describe("indoors.IndoorMapFloor", () => {
     it("is a function", () => {
-      expect(typeof indoors.IndoorMapFloor).toBe("function");
+      expect(typeof IndoorMapFloor).toBe("function");
     });
   });
 });

--- a/src/__tests__/wrld.test.ts
+++ b/src/__tests__/wrld.test.ts
@@ -1,6 +1,5 @@
-import Map from "../../types/map";
-
-import Wrld from "../wrld";
+import type Map from "../../types/map";
+import Wrld from "../wrld.js";
 
 describe("Wrld.map", () => {
   const elementId = "map";

--- a/src/private/blue_sphere_module.js
+++ b/src/private/blue_sphere_module.js
@@ -1,6 +1,6 @@
 import MapModule from "./map_module";
 
-function BlueSphereModule(emscriptenApi) {
+export function BlueSphereModule(emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _ready = false;
@@ -13,69 +13,55 @@ function BlueSphereModule(emscriptenApi) {
     var _stateChanged = false;
     var _showOrientation = true;
 
-    this.isEnabled = function() {
-        return _isEnabled;
-    };
+    this.isEnabled = () => _isEnabled;
 
-    this.setEnabled = function(isEnabled) {
+    this.setEnabled = (isEnabled) => {
         _isEnabled = isEnabled ? true : false;
     };
 
-    this.getLocation = function() {
-        return _location;
-    };
+    this.getLocation = () => _location;
 
-    this.setLocation = function (location) {
+    this.setLocation = (location) => {
         _location = L.latLng(location);
         _stateChanged = true;
     };
 
-    this.getIndoorMapId = function () {
-        return _indoorMapId;
-    };
+    this.getIndoorMapId = () => _indoorMapId;
 
-    this.getIndoorMapFloorId = function () {
-        return _indoorMapFloorId;
-    };
+    this.getIndoorMapFloorId = () => _indoorMapFloorId;
 
-    this.setIndoorMap = function (indoorMapId, indoorMapFloorId) {
+    this.setIndoorMap = (indoorMapId, indoorMapFloorId) => {
         _indoorMapId = indoorMapId;
         _indoorMapFloorId = indoorMapFloorId;
     };
 
-    this.isOrientationVisible = function () {
-        return _showOrientation;
-    };
+    this.isOrientationVisible = () => _showOrientation;
 
-    this.getHeadingDegrees = function () {
-        return _headingDegrees;
-    };
+    this.getHeadingDegrees = () => _headingDegrees;
 
-    this.setHeadingDegrees = function (headingDegrees) {
+    this.setHeadingDegrees = (headingDegrees) => {
         _headingDegrees = headingDegrees;
         _stateChanged = true;
     };
 
-    this.getElevation = function () {
-        return _elevation;
-    };
+    this.getElevation = () => _elevation;
 
-    this.setElevation = function (elevation) {
+    this.setElevation = (elevation) => {
         _elevation = elevation;
         _stateChanged = true;
     };
 
-    this.showOrientation = function (isVisible) {
+    this.showOrientation = (isVisible) => {
         _showOrientation = isVisible;
         _stateChanged = true;
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
         _emscriptenApi.blueSphereApi.updateNativeState(this);
     };
 
-    this.onUpdate = function() {
+    this.onUpdate = () => {
         if (_ready && _stateChanged) {
             _emscriptenApi.blueSphereApi.updateNativeState(this);
             _stateChanged = false;

--- a/src/private/blue_sphere_module.js
+++ b/src/private/blue_sphere_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 function BlueSphereModule(emscriptenApi) {
 
@@ -83,6 +83,7 @@ function BlueSphereModule(emscriptenApi) {
     };
 
 }
+
 BlueSphereModule.prototype = MapModule;
 
-module.exports = BlueSphereModule;
+export default BlueSphereModule;

--- a/src/private/buildings_module.js
+++ b/src/private/buildings_module.js
@@ -1,6 +1,6 @@
 import MapModule from "./map_module";
 
-function BuildingsModuleImpl(emscriptenApi) {
+export function BuildingsModuleImpl(emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _nativeIdToBuildingHighlights = {};
@@ -9,19 +9,19 @@ function BuildingsModuleImpl(emscriptenApi) {
     var _ready = false;
     var _notifyBuildingInformationReceivedCallback = null;
 
-    var _createPendingBuildingHighlights = function() {
-        _pendingBuildingHighlights.forEach(function(buildingHighlight) {
-            _createAndAdd(buildingHighlight);
-        });
+    var _createPendingBuildingHighlights = () => {
+        _pendingBuildingHighlights.forEach((buildingHighlight) => {
+                _createAndAdd(buildingHighlight);
+            });
         _pendingBuildingHighlights = [];
     };
 
-    var _createAndAdd = function(buildingHighlight) {
+    var _createAndAdd = (buildingHighlight) => {
         var nativeId = _emscriptenApi.buildingsApi.createBuildingHighlight(buildingHighlight);
         _nativeIdToBuildingHighlights[nativeId] = buildingHighlight;
         buildingHighlight._setNativeHandle(nativeId);
-        
-        if(nativeId in _callbackInvokedBeforeAssignement){
+
+        if (nativeId in _callbackInvokedBeforeAssignement) {
             delete _callbackInvokedBeforeAssignement[nativeId];
             _notifyBuildingInformationReceived(nativeId);
         }
@@ -29,7 +29,7 @@ function BuildingsModuleImpl(emscriptenApi) {
         return nativeId;
     };
 
-    this.addBuildingHighlight = function(buildingHighlight) {
+    this.addBuildingHighlight = (buildingHighlight) => {
         if (_ready) {
             _createAndAdd(buildingHighlight);
         }
@@ -38,7 +38,7 @@ function BuildingsModuleImpl(emscriptenApi) {
         }
     };
 
-    this.removeBuildingHighlight = function(buildingHighlight) {
+    this.removeBuildingHighlight = (buildingHighlight) => {
 
         if (!_ready) {
             var index = _pendingBuildingHighlights.indexOf(buildingHighlight);
@@ -58,7 +58,7 @@ function BuildingsModuleImpl(emscriptenApi) {
         buildingHighlight._setNativeHandle(null);
     };
 
-    this.notifyBuildingHighlightChanged = function(buildingHighlight) {
+    this.notifyBuildingHighlightChanged = (buildingHighlight) => {
         if (_ready) {
             var nativeId = buildingHighlight.getId();
             if (nativeId === undefined) {
@@ -68,14 +68,14 @@ function BuildingsModuleImpl(emscriptenApi) {
         }
     };
 
-    this.findIntersectionWithBuilding = function(ray) {
+    this.findIntersectionWithBuilding = (ray) => {
         if (!_ready) {
             return undefined;
         }
         return _emscriptenApi.buildingsApi.findIntersectionWithBuilding(ray);
     };
 
-    this.findBuildingAtScreenPoint = function(screenPoint) {
+    this.findBuildingAtScreenPoint = (screenPoint) => {
         if (!_ready) {
             return undefined;
         }
@@ -84,7 +84,7 @@ function BuildingsModuleImpl(emscriptenApi) {
         return this.findIntersectionWithBuilding(ray);
     };
 
-    this.findBuildingAtLatLng = function(latLng) {
+    this.findBuildingAtLatLng = (latLng) => {
         if (!_ready) {
             return undefined;
         }
@@ -93,30 +93,28 @@ function BuildingsModuleImpl(emscriptenApi) {
         return this.findIntersectionWithBuilding(ray);
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
         _emscriptenApi.buildingsApi.registerBuildingInformationReceivedCallback(_executeBuildingInformationReceivedCallback);
         _createPendingBuildingHighlights();
     };
 
-    this.isReady = function() {
-        return _ready;
-    };
+    this.isReady = () => _ready;
 
-    this.setBuildingInformationReceivedCallback = function(callback) {
+    this.setBuildingInformationReceivedCallback = (callback) => {
         _notifyBuildingInformationReceivedCallback = callback;
     };
 
-    var _executeBuildingInformationReceivedCallback = function(buildingHighlightId) {
+    var _executeBuildingInformationReceivedCallback = (buildingHighlightId) => {
         if (buildingHighlightId in _nativeIdToBuildingHighlights) {
             _notifyBuildingInformationReceived(buildingHighlightId);
         }
-        else{
+        else {
             _callbackInvokedBeforeAssignement[buildingHighlightId] = true;
         }
     };
 
-    var _notifyBuildingInformationReceived = function(buildingHighlightId) {
+    var _notifyBuildingInformationReceived = (buildingHighlightId) => {
         var buildingHighlight = _nativeIdToBuildingHighlights[buildingHighlightId];
         var buildingInformation = _emscriptenApi.buildingsApi.tryGetBuildingInformation(buildingHighlightId);
         if (buildingInformation !== null) {
@@ -132,26 +130,20 @@ function BuildingsModule(emscriptenApi) {
     var _buildingsModuleImpl = new BuildingsModuleImpl(emscriptenApi);
     var _this = this;
 
-    var _buildingInformationReceivedHandler = function(buildingHighlight) {
-        _this.fire("buildinginformationreceived", {buildingHighlight: buildingHighlight});
+    var _buildingInformationReceivedHandler = (buildingHighlight) => {
+        _this.fire("buildinginformationreceived", { buildingHighlight: buildingHighlight });
     };
 
-    this.findBuildingAtScreenPoint = function(screenPoint) {
-        return _buildingsModuleImpl.findBuildingAtScreenPoint(screenPoint);
-    };
+    this.findBuildingAtScreenPoint = (screenPoint) => _buildingsModuleImpl.findBuildingAtScreenPoint(screenPoint);
 
-    this.findBuildingAtLatLng = function(latLng) {
-        return _buildingsModuleImpl.findBuildingAtLatLng(latLng);
-    };
+    this.findBuildingAtLatLng = (latLng) => _buildingsModuleImpl.findBuildingAtLatLng(latLng);
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _buildingsModuleImpl.setBuildingInformationReceivedCallback(_buildingInformationReceivedHandler);
         _buildingsModuleImpl.onInitialized();
     };
 
-    this._getImpl = function() {
-        return _buildingsModuleImpl;
-    };
+    this._getImpl = () => _buildingsModuleImpl;
 }
 
 var BuildingsModulePrototype = L.extend({}, MapModule, L.Mixin.Events);

--- a/src/private/buildings_module.js
+++ b/src/private/buildings_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 function BuildingsModuleImpl(emscriptenApi) {
 
@@ -158,4 +158,4 @@ var BuildingsModulePrototype = L.extend({}, MapModule, L.Mixin.Events);
 
 BuildingsModule.prototype = BuildingsModulePrototype;
 
-module.exports = BuildingsModule;
+export default BuildingsModule;

--- a/src/private/callback_collection.js
+++ b/src/private/callback_collection.js
@@ -18,4 +18,4 @@ var CallbackCollection = function() {
     };
 };
 
-module.exports = CallbackCollection;
+export default CallbackCollection;

--- a/src/private/callback_collection.js
+++ b/src/private/callback_collection.js
@@ -1,4 +1,4 @@
-var CallbackCollection = function() {
+function CallbackCollection() {
 
     var _callbacks = [];
 
@@ -16,6 +16,6 @@ var CallbackCollection = function() {
             callback.apply(this, args);
         });
     };
-};
+}
 
 export default CallbackCollection;

--- a/src/private/camera_module.js
+++ b/src/private/camera_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 var CameraModule = function(
     emscriptenApi,
@@ -179,4 +179,5 @@ var CameraModule = function(
 };
 
 CameraModule.prototype = MapModule;
-module.exports = CameraModule;
+
+export default CameraModule;

--- a/src/private/camera_module.js
+++ b/src/private/camera_module.js
@@ -1,6 +1,6 @@
 import MapModule from "./map_module";
 
-var CameraModule = function(
+function CameraModule (
     emscriptenApi,
     startLatLng,
     initialZoom,
@@ -176,7 +176,7 @@ var CameraModule = function(
     this.setVerticallyLocked = function(isVerticallyLocked) {
          _setVerticallyLocked(isVerticallyLocked);
     };
-};
+}
 
 CameraModule.prototype = MapModule;
 

--- a/src/private/eegeo_dom_util.js
+++ b/src/private/eegeo_dom_util.js
@@ -1,6 +1,6 @@
 const tinyRotationString = " rotate(0.0001deg)";
 
-export const setPositionSmooth = function (el, point, disable3D) {
+export const setPositionSmooth = (el, point, disable3D) => {
   L.DomUtil.setPosition(el, point, disable3D);
 
   if (!disable3D && L.Browser.any3d) {

--- a/src/private/eegeo_dom_util.js
+++ b/src/private/eegeo_dom_util.js
@@ -1,12 +1,9 @@
-var tinyRotationString = " rotate(0.0001deg)";
+const tinyRotationString = " rotate(0.0001deg)";
 
-var EegeoDomUtil = {
-    setPositionSmooth: function(el, point, disable3D) {
-        L.DomUtil.setPosition(el, point, disable3D);
+export const setPositionSmooth = function (el, point, disable3D) {
+  L.DomUtil.setPosition(el, point, disable3D);
 
-        if (!disable3D && L.Browser.any3d) {
-            el.style[L.DomUtil.TRANSFORM] += tinyRotationString;
-        }
-    }
+  if (!disable3D && L.Browser.any3d) {
+    el.style[L.DomUtil.TRANSFORM] += tinyRotationString;
+  }
 };
-module.exports = EegeoDomUtil;

--- a/src/private/eegeo_map_controller.js
+++ b/src/private/eegeo_map_controller.js
@@ -23,7 +23,7 @@ import VersionModule from "./version_module";
 import HeatmapModule from "./heatmap_module";
 import FrameRateModule from "./frame_rate_module";
 
-const removeFileExtension = function(fileName, extensionToRemove) {
+const removeFileExtension = (fileName, extensionToRemove) => {
     var extensionPosition = fileName.lastIndexOf(".");
     var extension = fileName.slice(extensionPosition);
     if (extension === extensionToRemove) {
@@ -32,7 +32,7 @@ const removeFileExtension = function(fileName, extensionToRemove) {
     return fileName;
 };
 
-export const EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, browserWindow, browserDocument, module, options, onMapRemoveCallback) {
+export function EegeoMapController (mapId, emscriptenApi, domElement, apiKey, browserWindow, browserDocument, module, options, onMapRemoveCallback) {
 
     var _defaultOptions = {
         canvasId: "canvas",
@@ -287,6 +287,6 @@ export const EegeoMapController = function (mapId, emscriptenApi, domElement, ap
         });
         _this.leafletMap.onInitialStreamingCompleted();
     };
-};
+}
 
 export default EegeoMapController;

--- a/src/private/eegeo_map_controller.js
+++ b/src/private/eegeo_map_controller.js
@@ -1,29 +1,29 @@
-var HTMLMapContainer = require("./html_map_container");
-var ThemesModule = require("./themes_module");
-var IndoorsModule = require("./indoors_module");
-var PrecacheModule = require("./precache_module");
-var CameraModule = require("./camera_module");
-var PolygonModule = require("./polygon_module");
-var PolylineModule = require("./polyline_module");
-var RoutingModule = require("./routing_module");
-var RenderingModule = require("./rendering_module");
-var BuildingsModule = require("./buildings_module");
-var PropModule = require("./prop_module");
-var IndoorMapEntityInformationModule = require("./indoor_map_entity_information_module");
-var IndoorMapFloorOutlineInformationModule = require("./indoor_map_floor_outline_information_module");
-var BlueSphereModule = require("./blue_sphere_module");
-var MapRuntimeModule = require("./map_runtime_module");
-var LayerPointMappingModule = require("./layer_point_mapping_module");
-var VersionModule = require("./version_module");
-var HeatmapModule = require("./heatmap_module");
-var FrameRateModule = require("./frame_rate_module");
+import EegeoLeafletMap from "../public/eegeo_leaflet_map";
 
-var IndoorEntranceMarkerUpdater = require("./indoor_entrance_marker_updater");
+import HTMLMapContainer from "./html_map_container";
+import IndoorEntranceMarkerUpdater from "./indoor_entrance_marker_updater";
+import MapMoveEvents from "./events/map_move_events";
 
-var EegeoLeafletMap = require("../public/eegeo_leaflet_map");
-var MapMoveEvents = require("./events/map_move_events");
+import ThemesModule from "./themes_module";
+import IndoorsModule from "./indoors_module";
+import PrecacheModule from "./precache_module";
+import CameraModule from "./camera_module";
+import PolygonModule from "./polygon_module";
+import PolylineModule from "./polyline_module";
+import RoutingModule from "./routing_module";
+import RenderingModule from "./rendering_module";
+import BuildingsModule from "./buildings_module";
+import PropModule from "./prop_module";
+import IndoorMapEntityInformationModule from "./indoor_map_entity_information_module";
+import IndoorMapFloorOutlineInformationModule from "./indoor_map_floor_outline_information_module";
+import BlueSphereModule from "./blue_sphere_module";
+import MapRuntimeModule from "./map_runtime_module";
+import LayerPointMappingModule from "./layer_point_mapping_module";
+import VersionModule from "./version_module";
+import HeatmapModule from "./heatmap_module";
+import FrameRateModule from "./frame_rate_module";
 
-var removeFileExtension = function(fileName, extensionToRemove) {
+const removeFileExtension = function(fileName, extensionToRemove) {
     var extensionPosition = fileName.lastIndexOf(".");
     var extension = fileName.slice(extensionPosition);
     if (extension === extensionToRemove) {
@@ -32,8 +32,7 @@ var removeFileExtension = function(fileName, extensionToRemove) {
     return fileName;
 };
 
-
-var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, browserWindow, browserDocument, module, options, onMapRemoveCallback) {
+export const EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, browserWindow, browserDocument, module, options, onMapRemoveCallback) {
 
     var _defaultOptions = {
         canvasId: "canvas",
@@ -290,4 +289,4 @@ var EegeoMapController = function (mapId, emscriptenApi, domElement, apiKey, bro
     };
 };
 
-module.exports = EegeoMapController;
+export default EegeoMapController;

--- a/src/private/elevation_mode.js
+++ b/src/private/elevation_mode.js
@@ -1,13 +1,13 @@
-var ElevationModeType = {
+export const ElevationModeType = {
     HEIGHT_ABOVE_GROUND: "heightAboveGround",
     HEIGHT_ABOVE_SEA_LEVEL: "heightAboveSeaLevel"
 };
 
-function isValidElevationMode(elevationMode) {
+export function isValidElevationMode(elevationMode) {
     return elevationMode === ElevationModeType.HEIGHT_ABOVE_GROUND || elevationMode === ElevationModeType.HEIGHT_ABOVE_SEA_LEVEL;
 }
 
-function getElevationModeInt(elevationModeString) {
+export function getElevationModeInt(elevationModeString) {
     var elevationModes = {
         heightAboveSeaLevel: 0,
         heightAboveGround: 1
@@ -22,10 +22,3 @@ function getElevationModeInt(elevationModeString) {
 
     return elevationModeInt;
 }
-
-module.exports = {
-    ElevationModeType: ElevationModeType,
-    isValidElevationMode: isValidElevationMode,
-    getElevationModeInt: getElevationModeInt
-};
-

--- a/src/private/elevation_mode.js
+++ b/src/private/elevation_mode.js
@@ -3,11 +3,11 @@ export const ElevationModeType = {
     HEIGHT_ABOVE_SEA_LEVEL: "heightAboveSeaLevel"
 };
 
-export function isValidElevationMode(elevationMode) {
+export const isValidElevationMode = (elevationMode) => {
     return elevationMode === ElevationModeType.HEIGHT_ABOVE_GROUND || elevationMode === ElevationModeType.HEIGHT_ABOVE_SEA_LEVEL;
-}
+};
 
-export function getElevationModeInt(elevationModeString) {
+export const getElevationModeInt = (elevationModeString) => {
     var elevationModes = {
         heightAboveSeaLevel: 0,
         heightAboveGround: 1
@@ -15,10 +15,10 @@ export function getElevationModeInt(elevationModeString) {
 
     var elevationModeInt = elevationModes.heightAboveGround;
 
-    if (elevationModeString && 
+    if (elevationModeString &&
         elevationModeString.toLowerCase() === ElevationModeType.HEIGHT_ABOVE_SEA_LEVEL.toLowerCase()) {
         elevationModeInt = elevationModes.heightAboveSeaLevel;
     }
 
     return elevationModeInt;
-}
+};

--- a/src/private/emscripten_api/emscripten_api.js
+++ b/src/private/emscripten_api/emscripten_api.js
@@ -48,7 +48,7 @@ export function EmscriptenApi(emscriptenModule) {
     this.heatmapApi = null;
     this.frameRateApi = null;
 
-    this.onInitialized = function(eegeoApiPointer, emscriptenApiPointer, onUpdateCallback, onDrawCallback, onInitialStreamingCompletedCallback) {
+    this.onInitialized = (eegeoApiPointer, emscriptenApiPointer, onUpdateCallback, onDrawCallback, onInitialStreamingCompletedCallback) => {
         _eegeoApiPointer = eegeoApiPointer;
         _emscriptenApiPointer = emscriptenApiPointer;
 
@@ -91,9 +91,7 @@ export function EmscriptenApi(emscriptenModule) {
         _ready = true;
     };
 
-    this.ready = function() {
-        return _ready;
-    };
+    this.ready = () => _ready;
 }
 
 export default EmscriptenApi;

--- a/src/private/emscripten_api/emscripten_api.js
+++ b/src/private/emscripten_api/emscripten_api.js
@@ -1,26 +1,26 @@
-var EmscriptenMemory = require("./emscripten_memory");
-var EmscriptenGeofenceApi = require("./emscripten_geofence_api.js");
-var EmscriptenIndoorsApi = require("./emscripten_indoors_api.js");
-var EmscriptenPrecacheApi = require("./emscripten_precache_api.js");
-var EmscriptenSpacesApi = require("./emscripten_spaces_api.js");
-var EmscriptenThemesApi = require("./emscripten_themes_api.js");
-var EmscriptenCameraApi = require("./emscripten_camera_api.js");
-var EmscriptenExpandFloorsApi = require("./emscripten_expand_floors_api.js");
-var EmscriptenIndoorEntityApi = require("./emscripten_indoor_entity_api.js");
-var EmscriptenBuildingsApi = require("./emscripten_buildings_api.js");
-var EmscriptenRenderingApi = require("./emscripten_rendering_api.js");
-var EmscriptenLayerPointMappingApi = require("./emscripten_layer_point_mapping_api.js");
-var EmscriptenPropsApi = require("./emscripten_props_api.js");
-var EmscriptenIndoorMapEntityInformationApi = require("./emscripten_indoor_map_entity_information_api.js");
-var EmscriptenIndoorMapFloorOutlineInformationApi = require("./emscripten_indoor_map_floor_outline_information_api.js");
-var EmscriptenPolylineApi = require("./emscripten_polyline_api.js");
-var EmscriptenBlueSphereApi = require("./emscripten_blue_sphere_api.js");
-var EmscriptenMapRuntimeApi = require("./emscripten_map_runtime_api.js");
-var EmscriptenVersionApi = require("./emscripten_version_api.js");
-var EmscriptenHeatmapApi = require("./emscripten_heatmap_api.js");
-var EmscriptenFrameRateApi = require("./emscripten_frame_rate_api.js");
+import EmscriptenMemory from "./emscripten_memory";
+import EmscriptenGeofenceApi from "./emscripten_geofence_api.js";
+import EmscriptenIndoorsApi from "./emscripten_indoors_api.js";
+import EmscriptenPrecacheApi from "./emscripten_precache_api.js";
+import EmscriptenSpacesApi from "./emscripten_spaces_api.js";
+import EmscriptenThemesApi from "./emscripten_themes_api.js";
+import EmscriptenCameraApi from "./emscripten_camera_api.js";
+import EmscriptenExpandFloorsApi from "./emscripten_expand_floors_api.js";
+import EmscriptenIndoorEntityApi from "./emscripten_indoor_entity_api.js";
+import EmscriptenBuildingsApi from "./emscripten_buildings_api.js";
+import EmscriptenRenderingApi from "./emscripten_rendering_api.js";
+import EmscriptenLayerPointMappingApi from "./emscripten_layer_point_mapping_api.js";
+import EmscriptenPropsApi from "./emscripten_props_api.js";
+import EmscriptenIndoorMapEntityInformationApi from "./emscripten_indoor_map_entity_information_api.js";
+import EmscriptenIndoorMapFloorOutlineInformationApi from "./emscripten_indoor_map_floor_outline_information_api.js";
+import EmscriptenPolylineApi from "./emscripten_polyline_api.js";
+import EmscriptenBlueSphereApi from "./emscripten_blue_sphere_api.js";
+import EmscriptenMapRuntimeApi from "./emscripten_map_runtime_api.js";
+import EmscriptenVersionApi from "./emscripten_version_api.js";
+import EmscriptenHeatmapApi from "./emscripten_heatmap_api.js";
+import EmscriptenFrameRateApi from "./emscripten_frame_rate_api.js";
 
-function EmscriptenApi(emscriptenModule) {
+export function EmscriptenApi(emscriptenModule) {
 
     var _emscriptenModule = emscriptenModule;
     var _ready = false;
@@ -96,4 +96,4 @@ function EmscriptenApi(emscriptenModule) {
     };
 }
 
-module.exports = EmscriptenApi;
+export default EmscriptenApi;

--- a/src/private/emscripten_api/emscripten_blue_sphere_api.js
+++ b/src/private/emscripten_api/emscripten_blue_sphere_api.js
@@ -57,4 +57,4 @@ function EmscriptenBlueSphereApi(emscriptenApiPointer, cwrap, emscriptenModule, 
     };
 }
 
-module.exports = EmscriptenBlueSphereApi;
+export default EmscriptenBlueSphereApi;

--- a/src/private/emscripten_api/emscripten_blue_sphere_api.js
+++ b/src/private/emscripten_api/emscripten_blue_sphere_api.js
@@ -1,5 +1,4 @@
-
-function EmscriptenBlueSphereApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenBlueSphereApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
     var _emscriptenApiPointer = emscriptenApiPointer;
 
     var _blueSphereApi_setEnabled = cwrap("blueSphereApi_setEnabled", null, ["number", "number"]);
@@ -9,7 +8,7 @@ function EmscriptenBlueSphereApi(emscriptenApiPointer, cwrap, emscriptenModule, 
     var _blueSphereApi_setHeadingDegrees = cwrap("blueSphereApi_setHeadingDegrees", null, ["number", "number"]);
     var _blueSphereApi_showOrientation = cwrap("blueSphereApi_showOrientation", null, ["number", "number"]);
 
-    this.updateNativeState = function (blueSphereModule) {
+    this.updateNativeState = (blueSphereModule) => {
         var location = blueSphereModule.getLocation();
         var indoorMapId = blueSphereModule.getIndoorMapId();
 

--- a/src/private/emscripten_api/emscripten_buildings_api.js
+++ b/src/private/emscripten_api/emscripten_buildings_api.js
@@ -1,6 +1,6 @@
 import { BuildingHighlightSelectionType, BuildingDimensions, BuildingContour, BuildingInformation } from "../../public/buildings/buildings";
 
-function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -13,11 +13,11 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
     var _buildingsApi_TryGetBuildingInformation = cwrap("buildingsApi_TryGetBuildingInformation", "number", ["number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number"]);
     var _buildingsApi_TryFindIntersectionWithBuilding = cwrap("buildingsApi_TryFindIntersectionWithBuilding", "number", ["number", "number", "number"]);
 
-    this.registerBuildingInformationReceivedCallback = function(callback) {
+    this.registerBuildingInformationReceivedCallback = (callback) => {
         _buildingsApi_SetBuildingHighlightChangedCallback(_emscriptenApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.createBuildingHighlight = function(buildingHighlight) {
+    this.createBuildingHighlight = (buildingHighlight) => {
         var buildingHighlightId = 0;
         var options = buildingHighlight.getOptions();
         var color = buildingHighlight.getColor();
@@ -30,10 +30,10 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
                 _emscriptenApiPointer,
                 latLng.lat,
                 latLng.lng,
-                color.x/255,
-                color.y/255,
-                color.z/255,
-                color.w/255,
+                color.x / 255,
+                color.y / 255,
+                color.z / 255,
+                color.w / 255,
                 shouldCreateView
             );
         }
@@ -43,10 +43,10 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
                 _emscriptenApiPointer,
                 point.x,
                 point.y,
-                color.x/255,
-                color.y/255,
-                color.z/255,
-                color.w/255,
+                color.x / 255,
+                color.y / 255,
+                color.z / 255,
+                color.w / 255,
                 shouldCreateView
             );
         }
@@ -55,15 +55,15 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
     };
 
 
-    this.destroyBuildingHighlight = function(buildingHighlightId) {
+    this.destroyBuildingHighlight = (buildingHighlightId) => {
         _buildingsApi_DestroyHighlight(_emscriptenApiPointer, buildingHighlightId);
     };
 
-    this.setHighlightColor = function(buildingHighlightId, color) {
-        _buildingsApi_SetHighlightColor(_emscriptenApiPointer, buildingHighlightId, color.x/255, color.y/255, color.z/255, color.w/255);
+    this.setHighlightColor = (buildingHighlightId, color) => {
+        _buildingsApi_SetHighlightColor(_emscriptenApiPointer, buildingHighlightId, color.x / 255, color.y / 255, color.z / 255, color.w / 255);
     };
 
-    this.tryGetBuildingInformation = function(buildingHighlightId) {
+    this.tryGetBuildingInformation = (buildingHighlightId) => {
         var buildingIdSizeBuf = _emscriptenMemory.createInt32Buffer(1);
         var contourPointsSizeBuf = _emscriptenMemory.createInt32Buffer(1);
         var buildingContoursSizeBuf = _emscriptenMemory.createInt32Buffer(1);
@@ -74,8 +74,7 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
         var contourPointsSize = _emscriptenMemory.consumeBufferToArray(contourPointsSizeBuf)[0];
         var buildingContoursSize = _emscriptenMemory.consumeBufferToArray(buildingContoursSizeBuf)[0];
 
-        if (!success)
-        {
+        if (!success) {
             return null;
         }
 
@@ -107,7 +106,7 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
             contourBottomAltitudeBuf.element_count,
             contourTopAltitudeBuf.ptr,
             contourTopAltitudeBuf.element_count
-            );
+        );
 
         var buildingId = _emscriptenMemory.consumeUtf8BufferToString(buildingIdBuf);
         var baseAltitude = _emscriptenMemory.consumeBufferToArray(baseAltitudeBuf);
@@ -145,7 +144,7 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
         return new BuildingInformation(buildingId, buildingDimensions, buildingContours);
     };
 
-    this.findIntersectionWithBuilding = function(ray) {
+    this.findIntersectionWithBuilding = (ray) => {
         var rayElements = [ray.origin.x, ray.origin.y, ray.origin.z, ray.direction.x, ray.direction.y, ray.direction.z];
 
         var rayBuffer = _emscriptenMemory.createBufferFromArray(rayElements, _emscriptenMemory.createDoubleBuffer);
@@ -159,12 +158,10 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
         var resultArray = _emscriptenMemory.consumeBufferToArray(intersectionLatLngAltBuffer);
 
         return {
-            found : didIntersect,
-            point : L.latLng(resultArray)
+            found: didIntersect,
+            point: L.latLng(resultArray)
         };
     };
-
-
 }
 
 export default EmscriptenBuildingsApi;

--- a/src/private/emscripten_api/emscripten_buildings_api.js
+++ b/src/private/emscripten_api/emscripten_buildings_api.js
@@ -1,4 +1,4 @@
-var buildings = require("../../public/buildings/buildings");
+import { BuildingHighlightSelectionType, BuildingDimensions, BuildingContour, BuildingInformation } from "../../public/buildings/buildings";
 
 function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
@@ -24,7 +24,7 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
 
         var shouldCreateView = options.getIsInformationOnly() ? 0 : 1;
 
-        if (options.getSelectionMode() === buildings.BuildingHighlightSelectionType.SELECT_AT_LOCATION) {
+        if (options.getSelectionMode() === BuildingHighlightSelectionType.SELECT_AT_LOCATION) {
             var latLng = options.getSelectionLocation();
             buildingHighlightId = _buildingsApi_CreateHighlightAtLocation(
                 _emscriptenApiPointer,
@@ -114,7 +114,7 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
         var topAltitude = _emscriptenMemory.consumeBufferToArray(topAltitudeBuf);
         var centroid = L.latLng(_emscriptenMemory.consumeBufferToArray(centroidBuf));
 
-        var buildingDimensions = new buildings.BuildingDimensions(baseAltitude, topAltitude, centroid);
+        var buildingDimensions = new BuildingDimensions(baseAltitude, topAltitude, centroid);
 
         var contourPointsLatLngDoubles = _emscriptenMemory.consumeBufferToArray(contourPointsLatLngDoublesBuf);
         var contourPointCounts = _emscriptenMemory.consumeBufferToArray(contourPointCountsBuf);
@@ -131,7 +131,7 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
                 var lng = contourPointsLatLngDoubles[pointBufferIndex++];
                 points.push(L.latLng(lat, lng));
             }
-            var contour = new buildings.BuildingContour(
+            var contour = new BuildingContour(
                 contourBottomAltitudes[contourIndex],
                 contourTopAltitudes[contourIndex],
                 points);
@@ -142,7 +142,7 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
             return null;
         }
 
-        return new buildings.BuildingInformation(buildingId, buildingDimensions, buildingContours);
+        return new BuildingInformation(buildingId, buildingDimensions, buildingContours);
     };
 
     this.findIntersectionWithBuilding = function(ray) {
@@ -167,4 +167,4 @@ function EmscriptenBuildingsApi(emscriptenApiPointer, cwrap, emscriptenModule, e
 
 }
 
-module.exports = EmscriptenBuildingsApi;
+export default EmscriptenBuildingsApi;

--- a/src/private/emscripten_api/emscripten_camera_api.js
+++ b/src/private/emscripten_api/emscripten_camera_api.js
@@ -115,4 +115,4 @@ function EmscriptenCameraApi(emscriptenApiPointer, cwrap, emscriptenModule, emsc
 
 }
 
-module.exports = EmscriptenCameraApi;
+export default EmscriptenCameraApi;

--- a/src/private/emscripten_api/emscripten_camera_api.js
+++ b/src/private/emscripten_api/emscripten_camera_api.js
@@ -1,4 +1,4 @@
-function EmscriptenCameraApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenCameraApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -14,13 +14,13 @@ function EmscriptenCameraApi(emscriptenApiPointer, cwrap, emscriptenModule, emsc
     var _cameraApi_getZoomLevel = cwrap("cameraApi_getZoomLevel", "number", ["number"]);
     var _cameraApi_setVerticallyLocked = cwrap("cameraApi_setVerticallyLocked", null, ["number", "number"]);
 
-    var _setView = function(animated, location, distance, headingDegrees, tiltDegrees, durationSeconds, jumpIfFarAway, allowInterruption) {
+    var _setView = (animated, location, distance, headingDegrees, tiltDegrees, durationSeconds, jumpIfFarAway, allowInterruption) => {
 
-       var modifyLocation = true;
-       if(location === null ) {
-         location = {lat:0, lng: 0, alt: 0};
-         modifyLocation = false;
-       }
+        var modifyLocation = true;
+        if (location === null) {
+            location = { lat: 0, lng: 0, alt: 0 };
+            modifyLocation = false;
+        }
 
         return _cameraApi_setViewUsingZenithAngle(
             _emscriptenApiPointer,
@@ -35,9 +35,7 @@ function EmscriptenCameraApi(emscriptenApiPointer, cwrap, emscriptenModule, emsc
         );
     };
 
-    var _setViewToBounds = function(northEast, southWest, animated, allowInterruption) {
-
-
+    var _setViewToBounds = (northEast, southWest, animated, allowInterruption) => {
         _cameraApi_setViewToBounds(
             _emscriptenApiPointer,
             northEast.lat, northEast.lng, northEast.alt || 0,
@@ -47,7 +45,7 @@ function EmscriptenCameraApi(emscriptenApiPointer, cwrap, emscriptenModule, emsc
         );
     };
 
-    this.setView = function(config) {
+    this.setView = (config) => {
         var animated = "animate" in config ? config["animate"] : true;
         var location = "location" in config ? L.latLng(config["location"]): null;
         var distance = "zoom" in config ? this.getDistanceFromZoomLevel(config["zoom"]) : "distance" in config ? config["distance"] : null;
@@ -61,7 +59,7 @@ function EmscriptenCameraApi(emscriptenApiPointer, cwrap, emscriptenModule, emsc
         return _setView(animated, location, distance, headingDegrees, tiltDegrees, durationSeconds, jumpIfFarAway, allowInterruption);
     };
 
-    this.setViewToBounds = function(config) {
+    this.setViewToBounds = (config) => {
         var bounds = L.latLngBounds(config["bounds"]);
         var animated = "animate" in config ? config["animate"] : true;
         var allowInterruption = "allowInterruption" in config ? config["allowInterruption"] : true;
@@ -74,45 +72,33 @@ function EmscriptenCameraApi(emscriptenApiPointer, cwrap, emscriptenModule, emsc
         );
     };
 
-    this.getDistanceToInterest = function() {
-        return _cameraApi_getDistanceToInterest(_emscriptenApiPointer);
-    };
+    this.getDistanceToInterest = () => _cameraApi_getDistanceToInterest(_emscriptenApiPointer);
 
-    this.getInterestLatLong = function() {
+    this.getInterestLatLong = () => {
         var latLong = [0, 0];
-        _emscriptenMemory.passDoubles(latLong, function(resultArray, arraySize) {
-            _cameraApi_getInterestLatLong(_emscriptenApiPointer, resultArray);
-            latLong = _emscriptenMemory.readDoubles(resultArray, 2);
-        });
+        _emscriptenMemory.passDoubles(latLong, (resultArray, arraySize) => {
+                _cameraApi_getInterestLatLong(_emscriptenApiPointer, resultArray);
+                latLong = _emscriptenMemory.readDoubles(resultArray, 2);
+            });
 
         return latLong;
     };
 
-    this.getPitchDegrees = function() {
+    this.getPitchDegrees = () => _cameraApi_getPitchDegrees(_emscriptenApiPointer);
 
-        return _cameraApi_getPitchDegrees(_emscriptenApiPointer);
-    };
+    this.getHeadingDegrees = () => _cameraApi_getHeadingDegrees(_emscriptenApiPointer);
 
-    this.getHeadingDegrees = function() {
-        return _cameraApi_getHeadingDegrees(_emscriptenApiPointer);
-    };
-
-    this.setEventCallback = function(callback) {
+    this.setEventCallback = (callback) => {
         _cameraApi_setEventCallback(_emscriptenApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.getDistanceFromZoomLevel = function(zoomLevel) {
-        return _cameraApi_getDistanceFromZoomLevel(_emscriptenApiPointer, zoomLevel);
-    };
+    this.getDistanceFromZoomLevel = (zoomLevel) => _cameraApi_getDistanceFromZoomLevel(_emscriptenApiPointer, zoomLevel);
 
-    this.getZoomLevel = function() {
-        return _cameraApi_getZoomLevel(_emscriptenApiPointer);
-    };
+    this.getZoomLevel = () => _cameraApi_getZoomLevel(_emscriptenApiPointer);
 
-    this.setVerticallyLocked = function(isVerticallyLocked) {
+    this.setVerticallyLocked = (isVerticallyLocked) => {
         _cameraApi_setVerticallyLocked(_emscriptenApiPointer, isVerticallyLocked);
     };
-
 }
 
 export default EmscriptenCameraApi;

--- a/src/private/emscripten_api/emscripten_expand_floors_api.js
+++ b/src/private/emscripten_api/emscripten_expand_floors_api.js
@@ -1,4 +1,4 @@
-function EmscriptenExpandFloorsApi(eegeoApiPointer, cwrap, emscriptenModule) {
+export function EmscriptenExpandFloorsApi(eegeoApiPointer, cwrap, emscriptenModule) {
 
     var _eegeoApiPointer = eegeoApiPointer;
     
@@ -13,52 +13,52 @@ function EmscriptenExpandFloorsApi(eegeoApiPointer, cwrap, emscriptenModule) {
     var _setExpandCallback = null;
     var _setExpandEndCallback = null;
 
-    this.expandIndoorMap = function() {
+    this.expandIndoorMap = () => {
         _expandIndoorMap = _expandIndoorMap || cwrap("expandIndoorMap", "number", ["number"]);
         return _expandIndoorMap(_eegeoApiPointer);
     };
 
-    this.collapseIndoorMap = function() {
+    this.collapseIndoorMap = () => {
         _collapseIndoorMap = _collapseIndoorMap || cwrap("collapseIndoorMap", null, ["number"]);
         return _collapseIndoorMap(_eegeoApiPointer);
     };
 
-    this.getFloorParam = function() {
+    this.getFloorParam = () => {
         _getFloorParam = _getFloorParam || cwrap("getFloorParam", null, ["number"]);
         return _getFloorParam(_eegeoApiPointer);
     };
 
-    this.setFloorParam = function(value) {
+    this.setFloorParam = (value) => {
         _setFloorParam = _setFloorParam || cwrap("setFloorParam", null, ["number", "number"]);
         return _setFloorParam(_eegeoApiPointer, value);
     };
 
-    this.setCollapseStartCallback = function(callback) {
+    this.setCollapseStartCallback = (callback) => {
         _setCollapseStartCallback = _setCollapseStartCallback || cwrap("setCollapseStartCallback", null, ["number", "number"]);
         _setCollapseStartCallback(_eegeoApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.setCollapseCallback = function(callback) {
+    this.setCollapseCallback = (callback) => {
         _setCollapseCallback = _setCollapseCallback || cwrap("setCollapseCallback", null, ["number", "number"]);
         _setCollapseCallback(_eegeoApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.setCollapseEndCallback = function(callback) {
+    this.setCollapseEndCallback = (callback) => {
         _setCollapseEndCallback = _setCollapseEndCallback || cwrap("setCollapseEndCallback", null, ["number", "number"]);
         _setCollapseEndCallback(_eegeoApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.setExpandStartCallback = function(callback) {
+    this.setExpandStartCallback = (callback) => {
         _setExpandStartCallback = _setExpandStartCallback || cwrap("setExpandStartCallback", null, ["number", "number"]);
         _setExpandStartCallback(_eegeoApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.setExpandCallback = function(callback) {
+    this.setExpandCallback = (callback) => {
         _setExpandCallback = _setExpandCallback || cwrap("setExpandCallback", null, ["number", "number"]);
         _setExpandCallback(_eegeoApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.setExpandEndCallback = function(callback) {
+    this.setExpandEndCallback = (callback) => {
         _setExpandEndCallback = _setExpandEndCallback || cwrap("setExpandEndCallback", null, ["number", "number"]);
         _setExpandEndCallback(_eegeoApiPointer, emscriptenModule.addFunction(callback));
     };

--- a/src/private/emscripten_api/emscripten_expand_floors_api.js
+++ b/src/private/emscripten_api/emscripten_expand_floors_api.js
@@ -64,4 +64,4 @@ function EmscriptenExpandFloorsApi(eegeoApiPointer, cwrap, emscriptenModule) {
     };
 }
 
-module.exports = EmscriptenExpandFloorsApi;
+export default EmscriptenExpandFloorsApi;

--- a/src/private/emscripten_api/emscripten_frame_rate_api.js
+++ b/src/private/emscripten_api/emscripten_frame_rate_api.js
@@ -30,4 +30,4 @@ function EmscriptenFrameRateApi(emscriptenApiPointer, cwrap, emscriptenModule, e
 
 }
 
-module.exports = EmscriptenFrameRateApi;
+export default EmscriptenFrameRateApi;

--- a/src/private/emscripten_api/emscripten_frame_rate_api.js
+++ b/src/private/emscripten_api/emscripten_frame_rate_api.js
@@ -1,4 +1,4 @@
-function EmscriptenFrameRateApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenFrameRateApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
 
@@ -8,26 +8,25 @@ function EmscriptenFrameRateApi(emscriptenApiPointer, cwrap, emscriptenModule, e
     var _frameRateApi_SetThrottleWhenIdleEnabled = cwrap("frameRateApi_SetThrottleWhenIdleEnabled", null, ["number", "number"]);
     var _frameRateApi_CancelThrottle = cwrap("frameRateApi_CancelThrottle", null, ["number"]);
 
-    this.setTargetVSyncInterval = function(targetVSyncInterval) {
+    this.setTargetVSyncInterval = (targetVSyncInterval) => {
         _frameRateApi_SetTargetVSyncInterval(_emscriptenApiPointer, targetVSyncInterval);
     };
 
-    this.setThrottledTargetFrameInterval = function(throttledTargetFrameIntervalMS) {
+    this.setThrottledTargetFrameInterval = (throttledTargetFrameIntervalMS) => {
         _frameRateApi_SetThrottledTargetFrameInterval(_emscriptenApiPointer, throttledTargetFrameIntervalMS);
     };
 
-    this.setIdleSecondsBeforeThrottle = function(idleSecondsBeforeThrottle) {
+    this.setIdleSecondsBeforeThrottle = (idleSecondsBeforeThrottle) => {
         _frameRateApi_SetIdleSecondsBeforeThrottle(_emscriptenApiPointer, idleSecondsBeforeThrottle);
     };
 
-    this.setThrottleWhenIdleEnabled = function(enabled) {
+    this.setThrottleWhenIdleEnabled = (enabled) => {
         _frameRateApi_SetThrottleWhenIdleEnabled(_emscriptenApiPointer, enabled ? 1 : 0);
     };
 
-    this.cancelThrottle = function() {
+    this.cancelThrottle = () => {
         _frameRateApi_CancelThrottle(_emscriptenApiPointer);
     };
-
 }
 
 export default EmscriptenFrameRateApi;

--- a/src/private/emscripten_api/emscripten_geofence_api.js
+++ b/src/private/emscripten_api/emscripten_geofence_api.js
@@ -1,5 +1,5 @@
-var elevationMode = require("../elevation_mode.js");
-var interopUtils = require("./emscripten_interop_utils.js");
+import { ElevationModeType } from "../elevation_mode.js";
+import { colorToVec4 } from "./emscripten_interop_utils.js";
 
 function EmscriptenGeofenceApi(eegeoApiPointer, cwrap, emscriptenModule) {
 
@@ -11,7 +11,7 @@ function EmscriptenGeofenceApi(eegeoApiPointer, cwrap, emscriptenModule) {
     
     this._getElevationIsAboveSeaLevelFromConfig = function(config) {
         var configUsingNewApi = typeof config.elevationMode !== "undefined";
-        return configUsingNewApi ? config.elevationMode.toLowerCase() === elevationMode.ElevationModeType.HEIGHT_ABOVE_SEA_LEVEL.toLowerCase() : 
+        return configUsingNewApi ? config.elevationMode.toLowerCase() === ElevationModeType.HEIGHT_ABOVE_SEA_LEVEL.toLowerCase() : 
             (config.offsetFromSeaLevel || false);
     };
     
@@ -72,9 +72,9 @@ function EmscriptenGeofenceApi(eegeoApiPointer, cwrap, emscriptenModule) {
     };
 
     this.setGeofenceColor = function(polygonId, color) {
-        var colorVec4 = interopUtils.colorToVec4(color);
+        var colorVec4 = colorToVec4(color);
         _setGeofenceColor(_eegeoApiPointer, polygonId, colorVec4.x/255, colorVec4.y/255, colorVec4.z/255, colorVec4.w/255);
     };
 }
 
-module.exports = EmscriptenGeofenceApi;
+export default EmscriptenGeofenceApi;

--- a/src/private/emscripten_api/emscripten_geofence_api.js
+++ b/src/private/emscripten_api/emscripten_geofence_api.js
@@ -1,7 +1,7 @@
 import { ElevationModeType } from "../elevation_mode.js";
 import { colorToVec4 } from "./emscripten_interop_utils.js";
 
-function EmscriptenGeofenceApi(eegeoApiPointer, cwrap, emscriptenModule) {
+export function EmscriptenGeofenceApi(eegeoApiPointer, cwrap, emscriptenModule) {
 
     var _eegeoApiPointer = eegeoApiPointer;
     var _emscriptenModule = emscriptenModule;
@@ -9,29 +9,29 @@ function EmscriptenGeofenceApi(eegeoApiPointer, cwrap, emscriptenModule) {
     var _setGeofenceColor = cwrap("setGeofenceColor", null, ["number", "number", "number", "number", "number", "number"]);
     var _createGeofenceFromRawCoords = cwrap("createGeofenceFromRawCoords", null, ["number", "number", "number", "number", "number", "number", "number", "string", "number", "number"]);
     
-    this._getElevationIsAboveSeaLevelFromConfig = function(config) {
-        var configUsingNewApi = typeof config.elevationMode !== "undefined";
-        return configUsingNewApi ? config.elevationMode.toLowerCase() === ElevationModeType.HEIGHT_ABOVE_SEA_LEVEL.toLowerCase() : 
-            (config.offsetFromSeaLevel || false);
+    this._getElevationIsAboveSeaLevelFromConfig = (config) => {
+      var configUsingNewApi = typeof config.elevationMode !== "undefined";
+      return configUsingNewApi ? config.elevationMode.toLowerCase() === ElevationModeType.HEIGHT_ABOVE_SEA_LEVEL.toLowerCase() :
+        (config.offsetFromSeaLevel || false);
     };
     
-    this._getAltitudeOffsetFromConfig = function(config) {
-        var configUsingNewApi = typeof config.elevation !== "undefined";
-        return configUsingNewApi ? config.elevation : (config.altitudeOffset || 0.0);
+    this._getAltitudeOffsetFromConfig = (config) => {
+      var configUsingNewApi = typeof config.elevation !== "undefined";
+      return configUsingNewApi ? config.elevation : (config.altitudeOffset || 0.0);
     };
 
-    this.createGeofence = function(outerPoints, holes, config) {
+    this.createGeofence = (outerPoints, holes, config) => {
       var coords = [];
       var ringVertexCounts = [];
       ringVertexCounts.push(outerPoints.length);
-      outerPoints.forEach(function(point) {
+      outerPoints.forEach((point) => {
         coords.push(point.lat);
         coords.push(point.lng);
       });
 
-      holes.forEach(function(ring) {
+      holes.forEach((ring) => {
         ringVertexCounts.push(ring.length);
-        ring.forEach(function(point) {
+        ring.forEach((point) => {
           coords.push(point.lat);
           coords.push(point.lng);
         });
@@ -67,13 +67,13 @@ function EmscriptenGeofenceApi(eegeoApiPointer, cwrap, emscriptenModule) {
       return polygonId;
     };
 
-    this.removeGeofence = function(polygonId) {
-        _removeGeofence(_eegeoApiPointer, polygonId);
+    this.removeGeofence = (polygonId) => {
+      _removeGeofence(_eegeoApiPointer, polygonId);
     };
 
-    this.setGeofenceColor = function(polygonId, color) {
-        var colorVec4 = colorToVec4(color);
-        _setGeofenceColor(_eegeoApiPointer, polygonId, colorVec4.x/255, colorVec4.y/255, colorVec4.z/255, colorVec4.w/255);
+    this.setGeofenceColor = (polygonId, color) => {
+      var colorVec4 = colorToVec4(color);
+      _setGeofenceColor(_eegeoApiPointer, polygonId, colorVec4.x / 255, colorVec4.y / 255, colorVec4.z / 255, colorVec4.w / 255);
     };
 }
 

--- a/src/private/emscripten_api/emscripten_heatmap_api.js
+++ b/src/private/emscripten_api/emscripten_heatmap_api.js
@@ -1,6 +1,6 @@
-var elevationMode = require("../elevation_mode.js");
-var heatmap = require("../../public/heatmap.js");
-var interopUtils = require("./emscripten_interop_utils.js");
+import { getElevationModeInt } from "../elevation_mode.js";
+import { HeatmapOcclusionMapFeature } from "../../public/heatmap.js";
+import { colorToRgba32 } from "./emscripten_interop_utils.js";
 
 
 function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
@@ -33,16 +33,16 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         var occludedMapFeaturesInt = 0;
 
         occludedMapFeatures.forEach(function(occlusionFeature) {
-            if (occlusionFeature === heatmap.HeatmapOcclusionMapFeature.GROUND) {
+            if (occlusionFeature === HeatmapOcclusionMapFeature.GROUND) {
                 occludedMapFeaturesInt = occludedMapFeaturesInt | 0x1;
             }
-            else if (occlusionFeature === heatmap.HeatmapOcclusionMapFeature.BUILDINGS) {
+            else if (occlusionFeature === HeatmapOcclusionMapFeature.BUILDINGS) {
                 occludedMapFeaturesInt = occludedMapFeaturesInt | 0x2;
             }
-            else if (occlusionFeature === heatmap.HeatmapOcclusionMapFeature.TREES) {
+            else if (occlusionFeature === HeatmapOcclusionMapFeature.TREES) {
                 occludedMapFeaturesInt = occludedMapFeaturesInt | 0x4;
             }
-            else if (occlusionFeature === heatmap.HeatmapOcclusionMapFeature.TRANSPORT) {
+            else if (occlusionFeature === HeatmapOcclusionMapFeature.TRANSPORT) {
                 occludedMapFeaturesInt = occludedMapFeaturesInt | 0x8;
             }
         });
@@ -90,7 +90,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         var indoorMapId = heatmap.getIndoorMapId();
         var indoorMapFloorId = heatmap.getIndoorMapFloorId();
         var elevation = heatmap.getElevation();
-        var elevationModeInt = elevationMode.getElevationModeInt(heatmap.getElevationMode());
+        var elevationModeInt = getElevationModeInt(heatmap.getElevationMode());
 
         // data
         var dataFlat = _buildFlatData(heatmap.getData());
@@ -109,7 +109,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         var gradientColors = [];
         heatmap.getColorGradient().forEach(function(gradient) {
             gradientStops.push(gradient.stop);
-            gradientColors.push(interopUtils.colorToRgba32(gradient.color));
+            gradientColors.push(colorToRgba32(gradient.color));
         });
 
         // heatmap_todo investigate supporting ES6 for Float32Array / typed arrays
@@ -195,7 +195,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         }
 
         if (changedFlags.elevation) {
-            var elevationModeInt = elevationMode.getElevationModeInt(heatmap.getElevationMode());
+            var elevationModeInt = getElevationModeInt(heatmap.getElevationMode());
             _heatmapApi_setElevation(
                 _emscriptenApiPointer,
                 heatmapId,
@@ -251,7 +251,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
             var gradientColors = [];
             heatmap.getColorGradient().forEach(function(gradient) {
                 gradientStops.push(gradient.stop);
-                gradientColors.push(interopUtils.colorToRgba32(gradient.color));
+                gradientColors.push(colorToRgba32(gradient.color));
             });
 
             var gradientStopsBuffer = _emscriptenMemory.createBufferFromArray(gradientStops, _emscriptenMemory.createDoubleBuffer);
@@ -338,4 +338,4 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
     };
 }
 
-module.exports = EmscriptenHeatmapApi;
+export default EmscriptenHeatmapApi;

--- a/src/private/emscripten_api/emscripten_heatmap_api.js
+++ b/src/private/emscripten_api/emscripten_heatmap_api.js
@@ -2,8 +2,7 @@ import { getElevationModeInt } from "../elevation_mode.js";
 import { HeatmapOcclusionMapFeature } from "../../public/heatmap.js";
 import { colorToRgba32 } from "./emscripten_interop_utils.js";
 
-
-function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
 
@@ -27,12 +26,10 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
     var _heatmapApi_useApproximation = cwrap("heatmapApi_useApproximation", null, ["number", "number", "number"]);
     var _heatmapApi_setData = cwrap("heatmapApi_setData", null, ["number", "number", "number", "number", "number", "number"]);
 
-
-
-    function occludedMapFeaturesToInt(occludedMapFeatures) {
+    const occludedMapFeaturesToInt = (occludedMapFeatures) => {
         var occludedMapFeaturesInt = 0;
 
-        occludedMapFeatures.forEach(function(occlusionFeature) {
+        occludedMapFeatures.forEach(function (occlusionFeature) {
             if (occlusionFeature === HeatmapOcclusionMapFeature.GROUND) {
                 occludedMapFeaturesInt = occludedMapFeaturesInt | 0x1;
             }
@@ -48,11 +45,11 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         });
 
         return occludedMapFeaturesInt;
-    }
+    };
 
-    function _buildFlatData(pointData) {
+    const _buildFlatData = (pointData) => {
         var dataFlat = [];
-        pointData.forEach(function(pointDatum) {
+        pointData.forEach((pointDatum) => {
             dataFlat.push(pointDatum.latLng.lat);
             dataFlat.push(pointDatum.latLng.lng);
             var altOrDefault = 0.0;
@@ -64,21 +61,21 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         });
 
         return dataFlat;
-    }
+    };
 
-    this.createHeatmap = function(heatmap) {
+    this.createHeatmap = (heatmap) => {
         // polygon
         var polygonCoords = [];
         var polygonRingVertexCounts = [];
 
-        heatmap.getPolygonPoints().forEach(function(ring) {
-          polygonRingVertexCounts.push(ring.length);
-          ring.forEach(function(point) {
-            polygonCoords.push(point.lat);
-            polygonCoords.push(point.lng);
-            polygonCoords.push(point.alt ? point.alt : 0.0);
-          });
-        });
+        heatmap.getPolygonPoints().forEach((ring) => {
+            polygonRingVertexCounts.push(ring.length);
+            ring.forEach((point) => {
+                polygonCoords.push(point.lat);
+                polygonCoords.push(point.lng);
+                polygonCoords.push(point.alt ? point.alt : 0.0);
+            });
+            });
 
         if (polygonCoords.length === 0) {
             polygonRingVertexCounts.push(0);
@@ -99,7 +96,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         var heatmapDensityStops = [];
         var heatmapRadii = [];
         var heatmapGains = [];
-        heatmap.getDensityStops().forEach(function(density) {
+        heatmap.getDensityStops().forEach((density) => {
             heatmapDensityStops.push(density.stop);
             heatmapRadii.push(density.radius);
             heatmapGains.push(density.gain);
@@ -107,7 +104,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
 
         var gradientStops = [];
         var gradientColors = [];
-        heatmap.getColorGradient().forEach(function(gradient) {
+        heatmap.getColorGradient().forEach((gradient) => {
             gradientStops.push(gradient.stop);
             gradientColors.push(colorToRgba32(gradient.color));
         });
@@ -173,11 +170,11 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         return heatmapId;
     };
 
-    this.destroyHeatmap = function(heatmapId) {
+    this.destroyHeatmap = (heatmapId) => {
         _heatmapApi_destroyHeatmap(_emscriptenApiPointer, heatmapId);
     };
 
-    this.updateNativeState = function(heatmapId, heatmap) {
+    this.updateNativeState = (heatmapId, heatmap) => {
         if (!heatmap._anyChanged()) {
             return;
         }
@@ -191,7 +188,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
                 indoorMapId,
                 indoorMapId.length,
                 heatmap.getIndoorMapFloorId()
-                );
+            );
         }
 
         if (changedFlags.elevation) {
@@ -201,7 +198,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
                 heatmapId,
                 heatmap.getElevation(),
                 elevationModeInt
-                );
+            );
         }
 
         if (changedFlags.densityBlend) {
@@ -249,7 +246,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         if (changedFlags.colorGradient) {
             var gradientStops = [];
             var gradientColors = [];
-            heatmap.getColorGradient().forEach(function(gradient) {
+            heatmap.getColorGradient().forEach((gradient) => {
                 gradientStops.push(gradient.stop);
                 gradientColors.push(colorToRgba32(gradient.color));
             });
@@ -282,7 +279,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
             var heatmapDensityStops = [];
             var heatmapRadii = [];
             var heatmapGains = [];
-            heatmap.getDensityStops().forEach(function(density) {
+            heatmap.getDensityStops().forEach((density) => {
                 heatmapDensityStops.push(density.stop);
                 heatmapRadii.push(density.radius);
                 heatmapGains.push(density.gain);
@@ -328,7 +325,7 @@ function EmscriptenHeatmapApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
                 pointDataBuf.element_count,
                 heatmap.getWeightMin(),
                 heatmap.getWeightMax()
-                );
+            );
 
             _emscriptenMemory.freeBuffer(pointDataBuf);
         }

--- a/src/private/emscripten_api/emscripten_indoor_entity_api.js
+++ b/src/private/emscripten_api/emscripten_indoor_entity_api.js
@@ -1,4 +1,4 @@
-function EmscriptenIndoorEntityApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenIndoorEntityApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -10,42 +10,42 @@ function EmscriptenIndoorEntityApi(emscriptenApiPointer, cwrap, emscriptenModule
     var _indoorEntityPickedCallback = null;
     
 
-    var _onIndoorEntityPicked = function(idsPtr) {
+    var _onIndoorEntityPicked = (idsPtr) => {
         if (_indoorEntityPickedCallback !== null) {
             var ids = _emscriptenMemory.stringifyPointer(idsPtr);
             _indoorEntityPickedCallback(ids);
         }
     };
 
-    var _setHighlights = function(ids, color, indoorMapId, borderThickness) {
-        _emscriptenMemory.passStrings(ids, function(resultStrings, stringArraySize){
-            _emscriptenMemory.passDoubles(color, function(doubleArray, arraySize) {
+    var _setHighlights = (ids, color, indoorMapId, borderThickness) => {
+        _emscriptenMemory.passStrings(ids, (resultStrings, stringArraySize) => {
+        _emscriptenMemory.passDoubles(color, (doubleArray, arraySize) => {
                 _indoorEntityApi_SetHighlightsWithBorderThickness(_emscriptenApiPointer, indoorMapId, resultStrings, stringArraySize, doubleArray, borderThickness);
             });
         });
     };
 
-    var _clearHighlights = function(ids, indoorMapId) {
-        _emscriptenMemory.passStrings(ids, function(resultStrings, stringArraySize){
+    var _clearHighlights = (ids, indoorMapId) => {
+        _emscriptenMemory.passStrings(ids, (resultStrings, stringArraySize) => {
             _indoorEntityApi_ClearHighlights(_emscriptenApiPointer, indoorMapId, resultStrings, stringArraySize);
         });
     };
 
-    var _clearAllHighlights = function() {
+    var _clearAllHighlights = () => {
         _indoorEntityApi_ClearAllHighlights(_emscriptenApiPointer);
     };
 
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         // register emscripten callbacks
         _indoorEntityApi_SetIndoorEntityPickedCallback(_emscriptenApiPointer, emscriptenModule.addFunction(_onIndoorEntityPicked));
     };
 
-    this.registerIndoorEntityPickedCallback = function(callback) {
+    this.registerIndoorEntityPickedCallback = (callback) => {
         _indoorEntityPickedCallback = callback;
     };
 
-    this.setHighlights = function(ids, color, indoorMapId, borderThickness) {
+    this.setHighlights = (ids, color, indoorMapId, borderThickness) => {
         if (indoorMapId === null || indoorMapId === undefined) {
             return;
         }
@@ -56,7 +56,7 @@ function EmscriptenIndoorEntityApi(emscriptenApiPointer, cwrap, emscriptenModule
         _setHighlights(ids, color, indoorMapId, borderThickness);
     };
     
-    this.clearHighlights = function(ids, indoorMapId) {
+    this.clearHighlights = (ids, indoorMapId) => {
         if (ids === undefined) {
             _clearAllHighlights();
         }

--- a/src/private/emscripten_api/emscripten_indoor_entity_api.js
+++ b/src/private/emscripten_api/emscripten_indoor_entity_api.js
@@ -73,4 +73,4 @@ function EmscriptenIndoorEntityApi(emscriptenApiPointer, cwrap, emscriptenModule
     };
 }
 
-module.exports = EmscriptenIndoorEntityApi;
+export default EmscriptenIndoorEntityApi;

--- a/src/private/emscripten_api/emscripten_indoor_map_entity_information_api.js
+++ b/src/private/emscripten_api/emscripten_indoor_map_entity_information_api.js
@@ -1,4 +1,4 @@
-var indoorMapEntities = require("../../public/indoorMapEntities/indoorMapEntities");
+import { IndoorMapEntity } from "../../public/indoorMapEntities/indoorMapEntities";
 
 function EmscriptenIndoorMapEntityInformationApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
     
@@ -164,7 +164,7 @@ function EmscriptenIndoorMapEntityInformationApi(emscriptenApiPointer, cwrap, em
                 latLngsPerContourHead++;
             }
 
-            var entity = new indoorMapEntities.IndoorMapEntity(indoorMapEntityId, indoorMapEntityFloorId, position, polygonPoints);
+            var entity = new IndoorMapEntity(indoorMapEntityId, indoorMapEntityFloorId, position, polygonPoints);
             indoorMapEntitiesList.push(entity);
         }
 
@@ -177,4 +177,4 @@ function EmscriptenIndoorMapEntityInformationApi(emscriptenApiPointer, cwrap, em
     };
 }
 
-module.exports = EmscriptenIndoorMapEntityInformationApi;
+export default EmscriptenIndoorMapEntityInformationApi;

--- a/src/private/emscripten_api/emscripten_indoor_map_entity_information_api.js
+++ b/src/private/emscripten_api/emscripten_indoor_map_entity_information_api.js
@@ -1,7 +1,6 @@
 import { IndoorMapEntity } from "../../public/indoorMapEntities/indoorMapEntities";
 
-function EmscriptenIndoorMapEntityInformationApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
-    
+export function EmscriptenIndoorMapEntityInformationApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
 
@@ -14,11 +13,11 @@ function EmscriptenIndoorMapEntityInformationApi(emscriptenApiPointer, cwrap, em
     var _indoorEntityInformationApi_TryGetIndoorMapEntityBuffersSize = cwrap("indoorEntityInformationApi_TryGetIndoorMapEntityBuffersSize", "number",  ["number", "number", "number", "number", "number"]);
     var _indoorEntityInformationApi_TryGetIndoorMapEntityModels = cwrap("indoorEntityInformationApi_TryGetIndoorMapEntityModels", "number" , ["number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number"]);
 
-    this.registerIndoorMapEntityInformationChangedCallback = function(callback) {
+    this.registerIndoorMapEntityInformationChangedCallback = (callback) => {
         _indoorEntityInformationApi_IndoorMapEntityInformationChangedCallback(_emscriptenApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.createIndoorMapEntityInformation = function(indoorEntityInformation) {
+    this.createIndoorMapEntityInformation = (indoorEntityInformation) => {
         var indoorEntityInformationId = 0;
 
         var indoorMapId = indoorEntityInformation.getIndoorMapId();
@@ -30,11 +29,11 @@ function EmscriptenIndoorMapEntityInformationApi(emscriptenApiPointer, cwrap, em
         return indoorEntityInformationId;
     };
 
-    this.destroyIndoorMapEntityInformation = function(IndoorMapEntityInformationId) {
+    this.destroyIndoorMapEntityInformation = (IndoorMapEntityInformationId) => {
         _indoorEntityInformationApi_DestroyIndoorMapEntityInformation(_emscriptenApiPointer, IndoorMapEntityInformationId);
     };
 
-    this.tryGetIndoorMapEntityInformation = function(IndoorMapEntityInformationId) {
+    this.tryGetIndoorMapEntityInformation = (IndoorMapEntityInformationId) => {
 
         //Get Current Load State
         var loadStateBuf = _emscriptenMemory.createInt32Buffer(1);

--- a/src/private/emscripten_api/emscripten_indoor_map_floor_outline_information_api.js
+++ b/src/private/emscripten_api/emscripten_indoor_map_floor_outline_information_api.js
@@ -1,7 +1,7 @@
 import IndoorMapFloorOutlinePolygon from "../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon";
 import IndoorMapFloorOutlinePolygonRing from "../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring";
 
-function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -14,11 +14,11 @@ function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwr
     var _indoorMapFloorOutlineInformationApi_TryGetIndoorMapFloorOutlinePolygonBufferSizes = cwrap("indoorMapFloorOutlineInformationApi_TryGetIndoorMapFloorOutlinePolygonBufferSizes", "number", ["number","number","number","number","number","number"]);
     var _indoorMapFloorOutlineInformationApi_TryGetIndoorMapFloorOutlinePolygon = cwrap("indoorMapFloorOutlineInformationApi_TryGetIndoorMapFloorOutlinePolygon", "number", ["number","number","number","number","number","number","number","number"]);
 
-    this.registerIndoorMapFloorOutlineInformationLoadedCallback = function(callback) {
+    this.registerIndoorMapFloorOutlineInformationLoadedCallback = (callback) => {
         _indoorMapFloorOutlineInformationApi_IndoorMapFloorOutlineInformationLoadedCallback(_emscriptenApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.createIndoorMapFloorOutlineInformation = function(indoorMapFloorOutlineInformation) {
+    this.createIndoorMapFloorOutlineInformation = (indoorMapFloorOutlineInformation) => {
         var indoorMapId = indoorMapFloorOutlineInformation.getIndoorMapId();
         var indoorMapFloorId = indoorMapFloorOutlineInformation.getIndoorMapFloorId();
 
@@ -30,15 +30,13 @@ function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwr
         return indoorMapFloorOutlineInformationId;
     };
 
-    this.destroyIndoorMapFloorOutlineInformation = function(indoorMapFloorOutlineInformationId) {
+    this.destroyIndoorMapFloorOutlineInformation = (indoorMapFloorOutlineInformationId) => {
         _indoorMapFloorOutlineInformationApi_DestroyIndoorMapFloorOutlineInformation(_emscriptenApiPointer, indoorMapFloorOutlineInformationId);
     };
 
-    this.getIndoorMapFloorOutlineInformationLoaded = function(indoorMapFloorOutlineInformationId) {
-        return _indoorMapFloorOutlineInformationApi_GetIndoorMapFloorOutlineInformationLoaded(_emscriptenApiPointer, indoorMapFloorOutlineInformationId);
-    };
+    this.getIndoorMapFloorOutlineInformationLoaded = (indoorMapFloorOutlineInformationId) => _indoorMapFloorOutlineInformationApi_GetIndoorMapFloorOutlineInformationLoaded(_emscriptenApiPointer, indoorMapFloorOutlineInformationId);
 
-    this.tryGetIndoorMapFloorOutlineInformation = function(indoorMapFloorOutlineInformationId) {
+    this.tryGetIndoorMapFloorOutlineInformation = (indoorMapFloorOutlineInformationId) => {
         //Get Count of IndoorMapFloorOutlines
         var indoorMapFloorOutlinesCountBuf = _emscriptenMemory.createInt32Buffer(1);
 
@@ -50,8 +48,7 @@ function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwr
 
         var indoorMapFloorOutlinesCount = _emscriptenMemory.consumeBufferToArray(indoorMapFloorOutlinesCountBuf)[0];
 
-        if (!success)
-        {
+        if (!success) {
             return null;
         }
 
@@ -76,8 +73,7 @@ function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwr
             var innerRingsCount = _emscriptenMemory.consumeBufferToArray(innerRingsCountBuf)[0];
             var innerRingsTotalPointCount = _emscriptenMemory.consumeBufferToArray(innerRingsTotalPointCountBuf)[0];
 
-            if (!success)
-            {
+            if (!success) {
                 return null;
             }
 
@@ -113,8 +109,7 @@ function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwr
                 innerRings.push(innerRing);
             }
 
-            if (!success)
-            {
+            if (!success) {
                 return null;
             }
 
@@ -125,7 +120,7 @@ function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwr
         return outlinePolygons;
     };
 
-    var _getOutlinePolygonRing = function(doublesLatLngArray, startIndex, pointCount) {
+    var _getOutlinePolygonRing = (doublesLatLngArray, startIndex, pointCount) => {
         var pointIndex = startIndex;
         var ringPoints = [];
 

--- a/src/private/emscripten_api/emscripten_indoor_map_floor_outline_information_api.js
+++ b/src/private/emscripten_api/emscripten_indoor_map_floor_outline_information_api.js
@@ -1,5 +1,5 @@
-var IndoorMapFloorOutlinePolygon = require("../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon");
-var IndoorMapFloorOutlinePolygonRing = require("../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring");
+import IndoorMapFloorOutlinePolygon from "../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon";
+import IndoorMapFloorOutlinePolygonRing from "../../public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring";
 
 function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
@@ -139,4 +139,4 @@ function EmscriptenIndoorMapFloorOutlineInformationApi(emscriptenApiPointer, cwr
     };
 }
 
-module.exports = EmscriptenIndoorMapFloorOutlineInformationApi;
+export default EmscriptenIndoorMapFloorOutlineInformationApi;

--- a/src/private/emscripten_api/emscripten_indoors_api.js
+++ b/src/private/emscripten_api/emscripten_indoors_api.js
@@ -1,4 +1,4 @@
-var interopUtils = require("./emscripten_interop_utils.js");
+import { colorToRgba32 } from "./emscripten_interop_utils.js";
 
 function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
@@ -276,7 +276,7 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
     };
 
     this.setBackgroundColor = function(color) {
-        var colorRGBA32 = interopUtils.colorToRgba32(color);
+        var colorRGBA32 = colorToRgba32(color);
         _indoorsApi_SetBackgroundColor(_emscriptenApiPointer, colorRGBA32);
     };
 
@@ -297,4 +297,4 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
     };
 }
 
-module.exports = EmscriptenIndoorsApi;
+export default EmscriptenIndoorsApi;

--- a/src/private/emscripten_api/emscripten_indoors_api.js
+++ b/src/private/emscripten_api/emscripten_indoors_api.js
@@ -1,6 +1,6 @@
 import { colorToRgba32 } from "./emscripten_interop_utils.js";
 
-function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -41,31 +41,31 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
     var _onIndoorMapLoaded = null;
     var _onIndoorMapUnloaded = null;
 
-    var _indoorMapEnteredHandler = function() {
+    var _indoorMapEnteredHandler = () => {
         if (_onIndoorMapEntered !== null) {
             _onIndoorMapEntered();
         }
     };
 
-    var _indoorMapEntryFailedHandler = function() {
+    var _indoorMapEntryFailedHandler = () => {
         if (_onIndoorMapEnterFailed !== null) {
             _onIndoorMapEnterFailed();
         }
     };
 
-    var _indoorMapExitedHandler = function() {
+    var _indoorMapExitedHandler = () => {
         if (_onIndoorMapExited !== null) {
             _onIndoorMapExited();
         }
     };
 
-    var _indoorMapFloorChangedHandler = function() {
+    var _indoorMapFloorChangedHandler = () => {
         if (_onIndoorMapFloorChanged !== null) {
             _onIndoorMapFloorChanged();
         }
     };
 
-    var _executeEntryMarkerCallback = function(callback, indoorMapIdPtr, indoorMapNamePtr, indoorMapLatLngPtr) {
+    var _executeEntryMarkerCallback = (callback, indoorMapIdPtr, indoorMapNamePtr, indoorMapLatLngPtr) => {
         var indoorMapId = _emscriptenMemory.stringifyPointer(indoorMapIdPtr);
         var indoorMapName = _emscriptenMemory.stringifyPointer(indoorMapNamePtr);
         var latLngArray = _emscriptenMemory.readDoubles(indoorMapLatLngPtr, 3);
@@ -73,33 +73,33 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         callback(indoorMapId, indoorMapName, markerLatLng);
     };
 
-    var _indoorMapEntryMarkerAddedHandler = function(indoorMapIdPtr, indoorMapNamePtr, indoorMapLatLngPtr) {
+    var _indoorMapEntryMarkerAddedHandler = (indoorMapIdPtr, indoorMapNamePtr, indoorMapLatLngPtr) => {
         if (_onIndoorMapEntryMarkerAdded !== null) {
             _executeEntryMarkerCallback(_onIndoorMapEntryMarkerAdded, indoorMapIdPtr, indoorMapNamePtr, indoorMapLatLngPtr);
         }
     };
 
-    var _indoorMapEntryMarkerRemovedHandler = function(indoorMapIdPtr, indoorMapNamePtr, indoorMapLatLngPtr) {
+    var _indoorMapEntryMarkerRemovedHandler = (indoorMapIdPtr, indoorMapNamePtr, indoorMapLatLngPtr) => {
         if (_onIndoorMapEntryMarkerRemoved !== null) {
             _executeEntryMarkerCallback(_onIndoorMapEntryMarkerRemoved, indoorMapIdPtr, indoorMapNamePtr, indoorMapLatLngPtr);
         }
     };
 
-    var _indoorMapLoadedHandler = function(indoorMapIdPtr) {
+    var _indoorMapLoadedHandler = (indoorMapIdPtr) => {
         if (_onIndoorMapLoaded !== null) {
             var indoorMapId = _emscriptenMemory.stringifyPointer(indoorMapIdPtr);
             _onIndoorMapLoaded(indoorMapId);
         }
     };
 
-    var _indoorMapUnloadedHandler = function(indoorMapIdPtr) {
+    var _indoorMapUnloadedHandler = (indoorMapIdPtr) => {
         if (_onIndoorMapUnloaded !== null) {
             var indoorMapId = _emscriptenMemory.stringifyPointer(indoorMapIdPtr);
             _onIndoorMapUnloaded(indoorMapId);
         }
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _indoorsApi_RegisterIndoorMapCallbacks(
             _emscriptenApiPointer,
             emscriptenModule.addFunction(_indoorMapEnteredHandler),
@@ -113,7 +113,7 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         );
     };
 
-    this.setNotificationCallbacks = function(
+    this.setNotificationCallbacks = (
         indoorMapEnteredCallback,
         indoorMapEnterFailedCallback,
         indoorMapExitedCallback,
@@ -122,7 +122,7 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         indoorMapEntryMarkerRemovedCallback,
         indoorMapLoadedCallback,
         indoorMapUnloadedCallback
-    ) {
+    ) => {
         _onIndoorMapEntered = indoorMapEnteredCallback;
         _onIndoorMapEnterFailed = indoorMapEnterFailedCallback;
         _onIndoorMapExited = indoorMapExitedCallback;
@@ -133,63 +133,63 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         _onIndoorMapUnloaded = indoorMapUnloadedCallback;
     };
 
-    this.enterIndoorMap = function(indoorMapId) {
+    this.enterIndoorMap = (indoorMapId) => {
         return _indoorsApi_EnterIndoorMap(_emscriptenApiPointer, indoorMapId);
     };
 
-    this.exitIndoorMap = function() {
+    this.exitIndoorMap = () => {
         _indoorsApi_ExitIndoorMap(_emscriptenApiPointer);
     };
 
-    this.hasActiveIndoorMap = function() {
+    this.hasActiveIndoorMap = () => {
         return !!_indoorsApi_HasActiveIndoorMap(_emscriptenApiPointer);
     };
 
-    this.getActiveIndoorMapId = function() {
+    this.getActiveIndoorMapId = () => {
         return _indoorsApi_GetActiveIndoorMapId(_emscriptenApiPointer);
     };
 
-    this.getActiveIndoorMapName = function() {
+    this.getActiveIndoorMapName = () => {
         return _indoorsApi_GetActiveIndoorMapName(_emscriptenApiPointer);
     };
 
-    this.getActiveIndoorMapSourceVendor = function() {
+    this.getActiveIndoorMapSourceVendor = () => {
         return _indoorsApi_GetActiveIndoorMapSourceVendor(_emscriptenApiPointer);
     };
 
-    this.getActiveIndoorMapFloorCount = function() {
+    this.getActiveIndoorMapFloorCount = () => {
         return _indoorsApi_GetActiveIndoorMapFloorCount(_emscriptenApiPointer);
     };
 
-    this.getActiveIndoorMapUserData = function() {
+    this.getActiveIndoorMapUserData = () => {
         return _indoorsApi_GetActiveIndoorMapUserData(_emscriptenApiPointer);
     };
 
-    this.getSelectedFloorIndex = function() {
+    this.getSelectedFloorIndex = () => {
         return _indoorsApi_GetSelectedFloorIndex(_emscriptenApiPointer);
     };
 
-    this.setSelectedFloorIndex = function(floorIndex) {
+    this.setSelectedFloorIndex = (floorIndex) => {
         return !!_indoorsApi_SetSelectedFloorIndex(_emscriptenApiPointer, floorIndex);
     };
 
-    this.getFloorName = function(floorIndex) {
+    this.getFloorName = (floorIndex) => {
         return _indoorsApi_GetFloorName(_emscriptenApiPointer, floorIndex);
     };
 
-    this.getFloorShortName = function(floorIndex) {
+    this.getFloorShortName = (floorIndex) => {
         return _indoorsApi_GetFloorShortName(_emscriptenApiPointer, floorIndex);
     };
 
-    this.getFloorNumber = function(floorIndex) {
+    this.getFloorNumber = (floorIndex) => {
         return _indoorsApi_GetFloorNumber(_emscriptenApiPointer, floorIndex);
     };
 
-    this.getFloorHeightAboveSeaLevel = function(floorIndex) {
+    this.getFloorHeightAboveSeaLevel = (floorIndex) => {
         return _indoorsApi_GetFloorHeightAboveSeaLevel(_emscriptenApiPointer, floorIndex);
     };
 
-    this.tryGetReadableName = function(indoorMapId) {
+    this.tryGetReadableName = (indoorMapId) => {
         var bufferSizeBuf = _emscriptenMemory.createInt32Buffer(1);
 
         var success = _indoorsApi_TryGetReadableNameBufferSize(
@@ -222,7 +222,7 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         return indoorMapReadableName;
     };
 
-    var _tryGetNativeIndoorMapFloorString = function(indoorMapId, indoorMapFloorId, nativeGetBufferSizeFunc, nativeGetStringFunc) {
+    var _tryGetNativeIndoorMapFloorString = (indoorMapId, indoorMapFloorId, nativeGetBufferSizeFunc, nativeGetStringFunc) => {
         var bufferSizeBuf = _emscriptenMemory.createInt32Buffer(1);
 
         var success = nativeGetBufferSizeFunc(
@@ -257,7 +257,7 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         return stringValue;
     };
 
-    this.tryGetFloorReadableName = function(indoorMapId, indoorMapFloorId) {
+    this.tryGetFloorReadableName = (indoorMapId, indoorMapFloorId) => {
         return _tryGetNativeIndoorMapFloorString(
             indoorMapId,
             indoorMapFloorId,
@@ -266,7 +266,7 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         );
     };
 
-    this.tryGetFloorShortName = function(indoorMapId, indoorMapFloorId) {
+    this.tryGetFloorShortName = (indoorMapId, indoorMapFloorId) => {
         return _tryGetNativeIndoorMapFloorString(
             indoorMapId,
             indoorMapFloorId,
@@ -275,24 +275,24 @@ function EmscriptenIndoorsApi(emscriptenApiPointer, cwrap, emscriptenModule, ems
         );
     };
 
-    this.setBackgroundColor = function(color) {
+    this.setBackgroundColor = (color) => {
         var colorRGBA32 = colorToRgba32(color);
         _indoorsApi_SetBackgroundColor(_emscriptenApiPointer, colorRGBA32);
     };
 
-    this.hideLabelsForEntities = function(entityNames) {
-        _emscriptenMemory.passStrings(entityNames, function(resultStrings, stringArraySize){
+    this.hideLabelsForEntities = (entityNames) => {
+        _emscriptenMemory.passStrings(entityNames, (resultStrings, stringArraySize) => {
             _indoorsApi_HideLabelsForEntities(_emscriptenApiPointer, resultStrings, stringArraySize);
         });
     };
 
-    this.showLabelsForEntities = function(entityNames) {
-        _emscriptenMemory.passStrings(entityNames, function(resultStrings, stringArraySize){
+    this.showLabelsForEntities = (entityNames) => {
+        _emscriptenMemory.passStrings(entityNames, (resultStrings, stringArraySize) => {
             _indoorsApi_ShowLabelsForEntities(_emscriptenApiPointer, resultStrings, stringArraySize);
         });
     };
 
-    this.showAllLabels = function() {
+    this.showAllLabels = () => {
         _indoorsApi_ShowAllLabels(_emscriptenApiPointer);
     };
 }

--- a/src/private/emscripten_api/emscripten_interop_utils.js
+++ b/src/private/emscripten_api/emscripten_interop_utils.js
@@ -1,11 +1,11 @@
 import { Vector4 } from "../../public/space";
 
-function vec4ToRgba32(v) {
+const vec4ToRgba32 = (v) => {
     var rgba = ((v.x & 0xFF) << 24) + ((v.y & 0xFF) << 16) + ((v.z & 0xFF) << 8) + (v.w & 0xFF);
     return rgba;
-}
+};
 
-function rgba32ToVec4(rgba) {
+const rgba32ToVec4 = (rgba) => {
     var vec4 = new Vector4(
         ((rgba >> 24) & 0xFF),
         ((rgba >> 16) & 0xFF),
@@ -13,9 +13,9 @@ function rgba32ToVec4(rgba) {
         (rgba & 0xFF)
     );
     return vec4;
-}
+};
 
-function hexToRgba32(hex) {
+const hexToRgba32 = (hex) => {
     // https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
 
     hex = hex.replace(/^#/, "");
@@ -36,9 +36,9 @@ function hexToRgba32(hex) {
     }
 
     return (rgb << 8) + a;
-}
+};
 
-function colorArrayToVector4(color) {
+const colorArrayToVector4 = (color) => {
     var r = 0.0;
     var g = 0.0;
     var b = 0.0;
@@ -59,9 +59,9 @@ function colorArrayToVector4(color) {
         throw new Error("Unable to parse color - value out of range: " + String(color));
     }
     return new Vector4(r, g, b, a);
-}
+};
 
-function colorObjectToVector4(color) {
+const colorObjectToVector4 = (color) => {
     var r = undefined;
     var g = undefined;
     var b = undefined;
@@ -103,10 +103,10 @@ function colorObjectToVector4(color) {
         throw new Error("Unable to parse color - value out of range: " + String(color));
     }
     return new Vector4(r, g, b, a);
-}
+};
 
-export function colorToRgba32(color) {
-    if (typeof(color) === "string") {
+export const colorToRgba32 = (color) => {
+    if (typeof (color) === "string") {
         return hexToRgba32(color);
     }
     else if (Array.isArray(color)) {
@@ -117,8 +117,8 @@ export function colorToRgba32(color) {
     }
 
     throw new Error("Unable to parse color: " + String(color));
-}
+};
 
-export function colorToVec4(color) {
+export const colorToVec4 = (color) => {
     return rgba32ToVec4(colorToRgba32(color));
-}
+};

--- a/src/private/emscripten_api/emscripten_interop_utils.js
+++ b/src/private/emscripten_api/emscripten_interop_utils.js
@@ -1,4 +1,4 @@
-var space = require("../../public/space");
+import { Vector4 } from "../../public/space";
 
 function vec4ToRgba32(v) {
     var rgba = ((v.x & 0xFF) << 24) + ((v.y & 0xFF) << 16) + ((v.z & 0xFF) << 8) + (v.w & 0xFF);
@@ -6,7 +6,7 @@ function vec4ToRgba32(v) {
 }
 
 function rgba32ToVec4(rgba) {
-    var vec4 = new space.Vector4(
+    var vec4 = new Vector4(
         ((rgba >> 24) & 0xFF),
         ((rgba >> 16) & 0xFF),
         ((rgba >> 8) & 0xFF),
@@ -58,7 +58,7 @@ function colorArrayToVector4(color) {
     if (isNaN(r) || isNaN(g) || isNaN(b) || isNaN(a)) {
         throw new Error("Unable to parse color - value out of range: " + String(color));
     }
-    return new space.Vector4(r, g, b, a);
+    return new Vector4(r, g, b, a);
 }
 
 function colorObjectToVector4(color) {
@@ -102,10 +102,10 @@ function colorObjectToVector4(color) {
     if (isNaN(r) || isNaN(g) || isNaN(b) || isNaN(a)) {
         throw new Error("Unable to parse color - value out of range: " + String(color));
     }
-    return new space.Vector4(r, g, b, a);
+    return new Vector4(r, g, b, a);
 }
 
-function colorToRgba32(color) {
+export function colorToRgba32(color) {
     if (typeof(color) === "string") {
         return hexToRgba32(color);
     }
@@ -119,11 +119,6 @@ function colorToRgba32(color) {
     throw new Error("Unable to parse color: " + String(color));
 }
 
-function colorToVec4(color) {
+export function colorToVec4(color) {
     return rgba32ToVec4(colorToRgba32(color));
 }
-
-module.exports = {
-    colorToRgba32: colorToRgba32,
-    colorToVec4: colorToVec4
-};

--- a/src/private/emscripten_api/emscripten_layer_point_mapping_api.js
+++ b/src/private/emscripten_api/emscripten_layer_point_mapping_api.js
@@ -1,4 +1,4 @@
-function EmscriptenLayerPointMappingApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenLayerPointMappingApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -16,49 +16,49 @@ function EmscriptenLayerPointMappingApi(emscriptenApiPointer, cwrap, emscriptenM
 
             var destBaseIndex = i * 2;
             latLngsNumberArray[destBaseIndex] = latLng.lat;
-            latLngsNumberArray[destBaseIndex + 1] = latLng.lng;            
+            latLngsNumberArray[destBaseIndex + 1] = latLng.lng;
         }
 
         return latLngsNumberArray;
     };
 
-    this.createPointMapping = function(layerId, elevation, elevationModeInt, indoorMapId, indoorMapFloorId, latLngs) {                
+    this.createPointMapping = (layerId, elevation, elevationModeInt, indoorMapId, indoorMapFloorId, latLngs) => {
         _createPointMapping = _createPointMapping || cwrap("createLayerMapping", null, ["number", "number", "number", "number", "string", "number", "number", "number", "number"]);
               
         var latLngsNumberArray = this._createLatLngsNumberArray(latLngs);
         
-        _emscriptenMemory.passDoubles(latLngsNumberArray, function(resultArray, arraySize) {            
+        _emscriptenMemory.passDoubles(latLngsNumberArray, (resultArray, arraySize) => {
             _createPointMapping(
                 _emscriptenApiPointer, layerId, elevation, elevationModeInt, indoorMapId, indoorMapId.length, indoorMapFloorId, resultArray, arraySize);
-        });        
+        });
     };
 
-    this.createPointMappingWithFloorIndex = function(layerId, elevation, elevationModeInt, indoorMapId, indoorMapFloorIndex, latLngs) {                
+    this.createPointMappingWithFloorIndex = (layerId, elevation, elevationModeInt, indoorMapId, indoorMapFloorIndex, latLngs) => {
         _createPointMappingWithFloorIndex = _createPointMappingWithFloorIndex || 
             cwrap("createLayerMappingWithFloorIndex", null, ["number", "number", "number", "number", "string", "number", "number", "number", "number"]);
               
         var latLngsNumberArray = this._createLatLngsNumberArray(latLngs);
         
-        _emscriptenMemory.passDoubles(latLngsNumberArray, function(resultArray, arraySize) {            
+        _emscriptenMemory.passDoubles(latLngsNumberArray, (resultArray, arraySize) => {
             _createPointMappingWithFloorIndex(
                 _emscriptenApiPointer, layerId, elevation, elevationModeInt, indoorMapId, indoorMapId.length, indoorMapFloorIndex, resultArray, arraySize);
         });        
     };
 
-    this.removePointMapping = function(layerId) {
+    this.removePointMapping = (layerId) => {
         _removePointMapping = _removePointMapping || cwrap("removeLayerMapping", null, ["number", "number"]);
 
         _removePointMapping(_emscriptenApiPointer, layerId);
     };
 
-    this.getLatLngsForLayer = function(layerId, latLngCount) {                
+    this.getLatLngsForLayer = (layerId, latLngCount) => {
         _getPointsOnMapForLayer = _getPointsOnMapForLayer || cwrap("getPointsOnMapForLayer", "number", ["number", "number", "number"]);
         var resultLatLngAltDoubles = new Array(latLngCount * 3);
 
-        _emscriptenMemory.passDoubles(resultLatLngAltDoubles, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(resultLatLngAltDoubles, (resultArray, arraySize) => {
             var expectedArrayLength = _getPointsOnMapForLayer(_emscriptenApiPointer, layerId, resultArray);
 
-            if(resultLatLngAltDoubles.length !== expectedArrayLength) {
+            if (resultLatLngAltDoubles.length !== expectedArrayLength) {
                 throw new Error("_getPointsOnMapForLayer : unexpected array length. Expected '" + expectedArrayLength + "' but was '" + resultLatLngAltDoubles.length + "'.");
             }
 
@@ -77,7 +77,7 @@ function EmscriptenLayerPointMappingApi(emscriptenApiPointer, cwrap, emscriptenM
         }
 
         return resultLatLngAlts;
-    };    
+    };
 }
 
 export default EmscriptenLayerPointMappingApi;

--- a/src/private/emscripten_api/emscripten_layer_point_mapping_api.js
+++ b/src/private/emscripten_api/emscripten_layer_point_mapping_api.js
@@ -80,4 +80,4 @@ function EmscriptenLayerPointMappingApi(emscriptenApiPointer, cwrap, emscriptenM
     };    
 }
 
-module.exports = EmscriptenLayerPointMappingApi;
+export default EmscriptenLayerPointMappingApi;

--- a/src/private/emscripten_api/emscripten_map_runtime_api.js
+++ b/src/private/emscripten_api/emscripten_map_runtime_api.js
@@ -19,4 +19,4 @@ function EmscriptenMapRuntimeApi(eegeoApiPointer, cwrap, emscriptenModule, emscr
 
 }
 
-module.exports = EmscriptenMapRuntimeApi;
+export default EmscriptenMapRuntimeApi;

--- a/src/private/emscripten_api/emscripten_map_runtime_api.js
+++ b/src/private/emscripten_api/emscripten_map_runtime_api.js
@@ -1,19 +1,19 @@
-function EmscriptenMapRuntimeApi(eegeoApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenMapRuntimeApi(eegeoApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _eegeoApiPointer = eegeoApiPointer;
     var _pauseWebgl = cwrap("webglPause", null, ["number"]);
     var _resumeWebgl = cwrap("webglResume", null, ["number"]);
     var _removeWebgl = cwrap("webglRemove", null, ["number"]);
 
-    this.onPause = function() {
+    this.onPause = () => {
         _pauseWebgl(_eegeoApiPointer);
     };
 
-    this.onResume = function() {
+    this.onResume = () => {
         _resumeWebgl(_eegeoApiPointer);
     };
 
-    this.onRemove = function() {
+    this.onRemove = () => {
         _removeWebgl(_eegeoApiPointer);
     };
 

--- a/src/private/emscripten_api/emscripten_memory.js
+++ b/src/private/emscripten_api/emscripten_memory.js
@@ -1,27 +1,26 @@
-
-function EmscriptenMemory(emscriptenModule) {
+export function EmscriptenMemory(emscriptenModule) {
 
     var _emscriptenModule = emscriptenModule;
 
-    this.readDoubles = function(pointer, count) {
+    this.readDoubles = (pointer, count) => {
         var result = [];
-        for (var i=0; i<count; ++i) {
-            var item = _emscriptenModule.getValue(pointer + i*8, "double");
+        for (var i = 0; i < count; ++i) {
+            var item = _emscriptenModule.getValue(pointer + i * 8, "double");
             result.push(item);
         }
         return result;
     };
 
-    this.passDoubles = function(double_array, func) {
+    this.passDoubles = (double_array, func) => {
         var pointer = _emscriptenModule._malloc(double_array.length * 8);
-        for (var i=0; i<double_array.length; ++i) {
-            _emscriptenModule.setValue(pointer + i*8, double_array[i], "double");
+        for (var i = 0; i < double_array.length; ++i) {
+            _emscriptenModule.setValue(pointer + i * 8, double_array[i], "double");
         }
         func(pointer, double_array.length);
         _emscriptenModule._free(pointer);
     };
 
-    this.passString = function(string, func) {
+    this.passString = (string, func) => {
         var utf8Length = _emscriptenModule.lengthBytesUTF8(string);
         var pointer = _emscriptenModule._malloc(utf8Length);
         _emscriptenModule.stringToUTF8(string, pointer, utf8Length);
@@ -29,39 +28,37 @@ function EmscriptenMemory(emscriptenModule) {
         _emscriptenModule._free(pointer);
     };
 
-    this.passStrings = function(string_array, func) {
+    this.passStrings = (string_array, func) => {
         // allocate array of pointers to strings
         // NB Emscripten heap pointers are 32 bits
-        var pointer = _emscriptenModule._malloc(string_array.length*4);
+        var pointer = _emscriptenModule._malloc(string_array.length * 4);
         var strs = [];
-        for (var i=0; i<string_array.length; ++i) {
+        for (var i = 0; i < string_array.length; ++i) {
             var utf8Length = _emscriptenModule.lengthBytesUTF8(string_array[i]) + 1;
             var str = _emscriptenModule._malloc(utf8Length);
-            _emscriptenModule.stringToUTF8(string_array[i],str, utf8Length);
-            _emscriptenModule.setValue(pointer + i*4, str, "*");
+            _emscriptenModule.stringToUTF8(string_array[i], str, utf8Length);
+            _emscriptenModule.setValue(pointer + i * 4, str, "*");
             strs.push(str);
         }
         func(pointer, string_array.length);
-        for (var j=0; j<strs.length; ++j) {
+        for (var j = 0; j < strs.length; ++j) {
             _emscriptenModule._free(strs[j]);
         }
         _emscriptenModule._free(pointer);
     };
 
-    this.passInt32s = function(int32_array, func) {
+    this.passInt32s = (int32_array, func) => {
         var pointer = _emscriptenModule._malloc(int32_array.length * 4);
-        for (var i=0; i<int32_array.length; ++i) {
-            _emscriptenModule.setValue(pointer + i*4, int32_array[i], "i32");
+        for (var i = 0; i < int32_array.length; ++i) {
+            _emscriptenModule.setValue(pointer + i * 4, int32_array[i], "i32");
         }
         func(pointer, int32_array.length);
-        _emscriptenModule._free(pointer);  
+        _emscriptenModule._free(pointer);
     };
 
-    this.stringifyPointer = function(ptr) {
-      return _emscriptenModule.UTF8ToString(ptr);
-    };
+    this.stringifyPointer = (ptr) => _emscriptenModule.UTF8ToString(ptr);
 
-    this.createInt8Buffer = function(bufferLen) {
+    this.createInt8Buffer = (bufferLen) => {
         var bufferPtr = _emscriptenModule._malloc(bufferLen);
         return {
             ptr: bufferPtr,
@@ -71,7 +68,7 @@ function EmscriptenMemory(emscriptenModule) {
         };
     };
 
-    this.createInt32Buffer = function(elementCount) {
+    this.createInt32Buffer = (elementCount) => {
         var elementSizeBytes = 4;
         var bufferPtr = _emscriptenModule._malloc(elementCount * elementSizeBytes);
         return {
@@ -82,7 +79,7 @@ function EmscriptenMemory(emscriptenModule) {
         };
     };
 
-    this.createDoubleBuffer = function(elementCount) {
+    this.createDoubleBuffer = (elementCount) => {
         var elementSizeBytes = 8;
         var bufferPtr = _emscriptenModule._malloc(elementCount * elementSizeBytes);
         return {
@@ -93,36 +90,36 @@ function EmscriptenMemory(emscriptenModule) {
         };
     };
 
-    this.createBufferFromArray = function(number_array, createXBufferFunc) {
+    this.createBufferFromArray = (number_array, createXBufferFunc) => {
         var buffer = createXBufferFunc(number_array.length);
         for (var i = 0; i < buffer.element_count; ++i) {
-            _emscriptenModule.setValue(buffer.ptr + i*buffer.element_size_bytes, number_array[i], buffer.element_type);
+            _emscriptenModule.setValue(buffer.ptr + i * buffer.element_size_bytes, number_array[i], buffer.element_type);
         }
         return buffer;
     };
 
-    this.consumeBufferToArray = function(buffer) {
+    this.consumeBufferToArray = (buffer) => {
         var result = [];
         for (var i = 0; i < buffer.element_count; ++i) {
-            var item = _emscriptenModule.getValue(buffer.ptr + i*buffer.element_size_bytes, buffer.element_type);
+            var item = _emscriptenModule.getValue(buffer.ptr + i * buffer.element_size_bytes, buffer.element_type);
             result.push(item);
         }
         _emscriptenModule._free(buffer.ptr);
         return result;
     };
 
-    this.freeBuffer = function(buffer) {
+    this.freeBuffer = (buffer) => {
         _emscriptenModule._free(buffer.ptr);
     };
 
-    this.createUtf8BufferFromString = function(str) {
+    this.createUtf8BufferFromString = (str) => {
         var bufferLen = _emscriptenModule.lengthBytesUTF8(str) + 1;
         var buffer = this.createInt8Buffer(bufferLen);
         _emscriptenModule.stringToUTF8(str, buffer.ptr, bufferLen);
         return buffer;
     };
 
-    this.consumeUtf8BufferToString = function(buffer) {
+    this.consumeUtf8BufferToString = (buffer) => {
         var result = _emscriptenModule.UTF8ToString(buffer.ptr);
         _emscriptenModule._free(buffer.ptr);
         return result;

--- a/src/private/emscripten_api/emscripten_memory.js
+++ b/src/private/emscripten_api/emscripten_memory.js
@@ -129,4 +129,4 @@ function EmscriptenMemory(emscriptenModule) {
     };
 }
 
-module.exports = EmscriptenMemory;
+export default EmscriptenMemory;

--- a/src/private/emscripten_api/emscripten_polyline_api.js
+++ b/src/private/emscripten_api/emscripten_polyline_api.js
@@ -1,5 +1,5 @@
-var elevationMode = require("../elevation_mode.js");
-var interopUtils = require("./emscripten_interop_utils.js");
+import { getElevationModeInt } from "../elevation_mode.js";
+import { colorToRgba32 } from "./emscripten_interop_utils.js";
 
 function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
     var _emscriptenApiPointer = emscriptenApiPointer;
@@ -36,9 +36,9 @@ function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, em
         var indoorMapId = polyline.getIndoorMapId();
         var indoorMapFloorId = polyline.getIndoorMapFloorId();
         var elevation = polyline.getElevation();
-        var elevationModeInt = elevationMode.getElevationModeInt(polyline.getElevationMode());
+        var elevationModeInt = getElevationModeInt(polyline.getElevationMode());
         var width = polyline.getWidth();
-        var colorRGBA32 = interopUtils.colorToRgba32(polyline.getColor());
+        var colorRGBA32 = colorToRgba32(polyline.getColor());
         var miterLimit = polyline.getMiterLimit();
 
         var polylineId = _polylineApi_createPolyline(
@@ -75,8 +75,8 @@ function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, em
         polyline._needsNativeUpdate = false;
 
         var indoorMapId = polyline.getIndoorMapId();
-        var elevationModeInt = elevationMode.getElevationModeInt(polyline.getElevationMode());
-        var colorRGBA32 = interopUtils.colorToRgba32(polyline.getColor());
+        var elevationModeInt = getElevationModeInt(polyline.getElevationMode());
+        var colorRGBA32 = colorToRgba32(polyline.getColor());
 
         _polylineApi_setIndoorMap(
             _emscriptenApiPointer,
@@ -103,4 +103,4 @@ function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, em
     };
 }
 
-module.exports = EmscriptenPolylineApi;
+export default EmscriptenPolylineApi;

--- a/src/private/emscripten_api/emscripten_polyline_api.js
+++ b/src/private/emscripten_api/emscripten_polyline_api.js
@@ -1,7 +1,7 @@
 import { getElevationModeInt } from "../elevation_mode.js";
 import { colorToRgba32 } from "./emscripten_interop_utils.js";
 
-function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
 
@@ -11,11 +11,11 @@ function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, em
     var _polylineApi_setElevation = cwrap("polylineApi_setElevation", null, ["number", "number", "number"]);
     var _polylineApi_setStyleAttributes = cwrap("polylineApi_setStyleAttributes", null, ["number", "number", "number", "number", "number"]);
 
-    this.createPolyline = function(polyline) {
+    this.createPolyline = (polyline) => {
         var coords = [];
         var perPointElevations = [];
         var anyAltitudes = false;
-        polyline.getLatLngs().forEach(function(latLng) {
+        polyline.getLatLngs().forEach((latLng) => {
             coords.push(latLng.lat);
             coords.push(latLng.lng);
             var altOrDefault = 0.0;
@@ -55,7 +55,7 @@ function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, em
             width,
             colorRGBA32,
             miterLimit
-            );
+        );
 
         _emscriptenMemory.freeBuffer(coordsBuf);
         _emscriptenMemory.freeBuffer(perPointElevationsBuf);
@@ -64,11 +64,11 @@ function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, em
         return polylineId;
     };
 
-    this.destroyPolyline = function(polylineId) {
+    this.destroyPolyline = (polylineId) => {
         _polylineApi_destroyPolyline(_emscriptenApiPointer, polylineId);
     };
 
-    this.updateNativeState = function(polylineId, polyline) {
+    this.updateNativeState = (polylineId, polyline) => {
         if (!polyline._needsNativeUpdate) {
             return;
         }
@@ -84,14 +84,14 @@ function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, em
             indoorMapId,
             indoorMapId.length,
             polyline.getIndoorMapFloorId()
-            );
+        );
 
         _polylineApi_setElevation(
             _emscriptenApiPointer,
             polylineId,
             polyline.getElevation(),
             elevationModeInt
-            );
+        );
 
         _polylineApi_setStyleAttributes(
             _emscriptenApiPointer,
@@ -99,7 +99,7 @@ function EmscriptenPolylineApi(emscriptenApiPointer, cwrap, emscriptenModule, em
             polyline.getWidth(),
             colorRGBA32,
             polyline.getMiterLimit()
-            );
+        );
     };
 }
 

--- a/src/private/emscripten_api/emscripten_precache_api.js
+++ b/src/private/emscripten_api/emscripten_precache_api.js
@@ -35,4 +35,4 @@ function EmscriptenPrecacheApi(emscriptenApiPointer, cwrap, emscriptenModule) {
     };
 }
 
-module.exports = EmscriptenPrecacheApi;
+export default EmscriptenPrecacheApi;

--- a/src/private/emscripten_api/emscripten_precache_api.js
+++ b/src/private/emscripten_api/emscripten_precache_api.js
@@ -1,5 +1,4 @@
-
-function EmscriptenPrecacheApi(emscriptenApiPointer, cwrap, emscriptenModule) {
+export function EmscriptenPrecacheApi(emscriptenApiPointer, cwrap, emscriptenModule) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _beginPrecacheOperation = null;
@@ -8,7 +7,7 @@ function EmscriptenPrecacheApi(emscriptenApiPointer, cwrap, emscriptenModule) {
     var _cancelCallback = null;
     var _completeCallback = null;
 
-    this.registerCallbacks = function(completeCallback, cancelCallback) {
+    this.registerCallbacks = (completeCallback, cancelCallback) => {
         if (_completeCallback !== null) {
             emscriptenModule.removeFunction(_completeCallback);
         }
@@ -18,18 +17,18 @@ function EmscriptenPrecacheApi(emscriptenApiPointer, cwrap, emscriptenModule) {
         }
         _cancelCallback = emscriptenModule.addFunction(cancelCallback);
 
-    _setPrecacheCallbacks = _setPrecacheCallbacks || cwrap("precacheApi_setPrecacheCallbacks", null, ["number", "number", "number"]);
-    _setPrecacheCallbacks(_emscriptenApiPointer, _completeCallback, _cancelCallback);
+        _setPrecacheCallbacks = _setPrecacheCallbacks || cwrap("precacheApi_setPrecacheCallbacks", null, ["number", "number", "number"]);
+        _setPrecacheCallbacks(_emscriptenApiPointer, _completeCallback, _cancelCallback);
     };
 
-    this.beginPrecacheOperation = function(operation) {      
+    this.beginPrecacheOperation = (operation) => {
         _beginPrecacheOperation = _beginPrecacheOperation || cwrap("precacheApi_beginPrecacheOperation", "number", ["number", "number", "number", "number"]);
-      
+
         var latlong = operation.getCentre();
         return _beginPrecacheOperation(_emscriptenApiPointer, latlong.lat, latlong.lng, operation.getRadius());
     };
 
-    this.cancelPrecacheOperation = function(operationId) {
+    this.cancelPrecacheOperation = (operationId) => {
         _cancelPrecacheOperation = _cancelPrecacheOperation || cwrap("precacheApi_cancelPrecacheOperation", null, ["number", "number"]);
         _cancelPrecacheOperation(_emscriptenApiPointer, operationId);
     };

--- a/src/private/emscripten_api/emscripten_props_api.js
+++ b/src/private/emscripten_api/emscripten_props_api.js
@@ -1,5 +1,5 @@
-var elevationMode = require("../elevation_mode.js");
-var indoorMapEntitySetProp = require("../../public/entity_set_prop.js");
+import { getElevationModeInt, ElevationModeType } from "../elevation_mode.js";
+import { IndoorMapEntitySetProp } from "../../public/entity_set_prop.js";
 
 function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
@@ -33,7 +33,7 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
 
     this.createProp = function(indoorMapId, floorId, name, latitude, longitude, elevation, elevationModeString, headingDegrees, geometryId) {
         _propsApi_createProp = _propsApi_createProp || cwrap("propsApi_createProp", "number", ["number", "string", "number", "string", "number", "number", "number", "number", "number", "string"]);
-        var elevationModeInt = elevationMode.getElevationModeInt(elevationModeString);
+        var elevationModeInt = getElevationModeInt(elevationModeString);
         var propId = _propsApi_createProp(_emscriptenApiPointer, indoorMapId, floorId, name, latitude, longitude, elevation, elevationModeInt, headingDegrees, geometryId);
         return propId;
     };
@@ -57,7 +57,7 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
         var out_propIdsBuffer = _emscriptenMemory.createInt32Buffer(propCount);
 
         var elevationModeIntArray = [];
-        elevationModeArray.forEach(function(elevationModeString){ elevationModeIntArray.push(elevationMode.getElevationModeInt(elevationModeString)); });
+        elevationModeArray.forEach(function(elevationModeString){ elevationModeIntArray.push(getElevationModeInt(elevationModeString)); });
 
         var floorIdBuffer = _emscriptenMemory.createBufferFromArray(floorIdArray, _emscriptenMemory.createInt32Buffer);
         var latitudeBuffer = _emscriptenMemory.createBufferFromArray(latitudeArray, _emscriptenMemory.createDoubleBuffer);
@@ -127,7 +127,7 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
 
     this.setElevationMode = function(propId, elevationModeString) {
         _propsApi_setElevationMode = _propsApi_setElevationMode || cwrap("propsApi_setElevationMode", null, ["number", "number", "number"]);
-        var elevationModeInt = elevationMode.getElevationModeInt(elevationModeString);
+        var elevationModeInt = getElevationModeInt(elevationModeString);
         _propsApi_setElevationMode(_emscriptenApiPointer, propId, elevationModeInt);
     };
 
@@ -233,7 +233,7 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
             var height = indoorMapPropHeights[i];
             var orientation = indoorMapPropOrientation[i];
 
-            var prop = new indoorMapEntitySetProp.IndoorMapEntitySetProp(indoorMapId, floorId, name, model, position, height, elevationMode.ElevationModeType.HEIGHT_ABOVE_GROUND, orientation);
+            var prop = new IndoorMapEntitySetProp(indoorMapId, floorId, name, model, position, height, ElevationModeType.HEIGHT_ABOVE_GROUND, orientation);
             indoorMapEntityPropList.push(prop);
         }
 
@@ -267,4 +267,4 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
     };
 }
 
-module.exports = EmscriptenPropsApi;
+export default EmscriptenPropsApi;

--- a/src/private/emscripten_api/emscripten_props_api.js
+++ b/src/private/emscripten_api/emscripten_props_api.js
@@ -1,7 +1,7 @@
 import { getElevationModeInt, ElevationModeType } from "../elevation_mode.js";
 import { IndoorMapEntitySetProp } from "../../public/entity_set_prop.js";
 
-function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -27,18 +27,18 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
 
     var _indoorMapEntitySetPropsLoadedCallback = null;
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         this.registerIndoorMapEntitySetPropsLoadedHandler(indoorMapEntitySetPropsLoadedHandler);
     };
 
-    this.createProp = function(indoorMapId, floorId, name, latitude, longitude, elevation, elevationModeString, headingDegrees, geometryId) {
+    this.createProp = (indoorMapId, floorId, name, latitude, longitude, elevation, elevationModeString, headingDegrees, geometryId) => {
         _propsApi_createProp = _propsApi_createProp || cwrap("propsApi_createProp", "number", ["number", "string", "number", "string", "number", "number", "number", "number", "number", "string"]);
         var elevationModeInt = getElevationModeInt(elevationModeString);
         var propId = _propsApi_createProp(_emscriptenApiPointer, indoorMapId, floorId, name, latitude, longitude, elevation, elevationModeInt, headingDegrees, geometryId);
         return propId;
     };
 
-    this.createProps = function(indoorMapIdArray, floorIdArray, nameArray, latitudeArray, longitudeArray, elevationArray, elevationModeArray, headingDegreesArray, geometryIdArray) {
+    this.createProps = (indoorMapIdArray, floorIdArray, nameArray, latitudeArray, longitudeArray, elevationArray, elevationModeArray, headingDegreesArray, geometryIdArray) => {
         var propCount = indoorMapIdArray.length;
 
         if (floorIdArray.length !== propCount ||
@@ -48,8 +48,7 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
             elevationArray.length !== propCount ||
             elevationModeArray.length !== propCount ||
             headingDegreesArray.length !== propCount ||
-            geometryIdArray.length !== propCount)
-        {
+            geometryIdArray.length !== propCount) {
             throw new Error("Unequal array element counts in call to createProps.");
         }
 
@@ -57,7 +56,7 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
         var out_propIdsBuffer = _emscriptenMemory.createInt32Buffer(propCount);
 
         var elevationModeIntArray = [];
-        elevationModeArray.forEach(function(elevationModeString){ elevationModeIntArray.push(getElevationModeInt(elevationModeString)); });
+        elevationModeArray.forEach(function (elevationModeString) { elevationModeIntArray.push(getElevationModeInt(elevationModeString)); });
 
         var floorIdBuffer = _emscriptenMemory.createBufferFromArray(floorIdArray, _emscriptenMemory.createInt32Buffer);
         var latitudeBuffer = _emscriptenMemory.createBufferFromArray(latitudeArray, _emscriptenMemory.createDoubleBuffer);
@@ -66,9 +65,9 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
         var elevationModeBuffer = _emscriptenMemory.createBufferFromArray(elevationModeIntArray, _emscriptenMemory.createInt32Buffer);
         var headingDegreesBuffer = _emscriptenMemory.createBufferFromArray(headingDegreesArray, _emscriptenMemory.createDoubleBuffer);
 
-        _emscriptenMemory.passStrings(indoorMapIdArray, function(indoorMapIdArrayPtr, indoorMapIdArraySize) {
-            _emscriptenMemory.passStrings(nameArray, function(nameArrayPtr, nameArraySize) {
-                _emscriptenMemory.passStrings(geometryIdArray, function(geometryIdArrayPtr, geometryIdArraySize) {
+        _emscriptenMemory.passStrings(indoorMapIdArray, (indoorMapIdArrayPtr, indoorMapIdArraySize) => {
+            _emscriptenMemory.passStrings(nameArray, (nameArrayPtr, nameArraySize) => {
+                _emscriptenMemory.passStrings(geometryIdArray, (geometryIdArrayPtr, geometryIdArraySize) => {
                     _propsApi_createProps(
                         _emscriptenApiPointer,
                         propCount,
@@ -97,61 +96,61 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
         return _emscriptenMemory.consumeBufferToArray(out_propIdsBuffer);
     };
 
-    this.destroyProp = function(propId) {
+    this.destroyProp = (propId) => {
         _propsApi_destroyProp = _propsApi_destroyProp || cwrap("propsApi_destroyProp", null, ["number", "number"]);
         _propsApi_destroyProp(_emscriptenApiPointer, propId);
     };
 
-    this.destroyProps = function(propIdArray) {
+    this.destroyProps = (propIdArray) => {
         _propsApi_destroyProps = _propsApi_destroyProps || cwrap("propsApi_destroyProps", null, ["number", "number", "number"]);
 
-        _emscriptenMemory.passInt32s(propIdArray, function(propIdArrayPtr, propIdArraySize){
+        _emscriptenMemory.passInt32s(propIdArray, (propIdArrayPtr, propIdArraySize) => {
             _propsApi_destroyProps(_emscriptenApiPointer, propIdArrayPtr, propIdArraySize);
         });
     };
 
-    this.propExists = function(propId) {
+    this.propExists = (propId) => {
         _propsApi_propExists = _propsApi_propExists || cwrap("propsApi_propExists", "number", ["number", "number"]);
         return _propsApi_propExists(_emscriptenApiPointer, propId);
     };
 
-    this.setLocation = function(propId, latitudeDegrees, longitudeDegrees) {
+    this.setLocation = (propId, latitudeDegrees, longitudeDegrees) => {
         _propsApi_setLocation = _propsApi_setLocation || cwrap("propsApi_setLocation", null, ["number", "number", "number", "number"]);
         _propsApi_setLocation(_emscriptenApiPointer, propId, latitudeDegrees, longitudeDegrees);
     };
 
-    this.setElevation = function(propId, elevation) {
+    this.setElevation = (propId, elevation) => {
         _propsApi_setElevation = _propsApi_setElevation || cwrap("propsApi_setElevation", null, ["number", "number", "number"]);
         _propsApi_setElevation(_emscriptenApiPointer, propId, elevation);
     };
 
-    this.setElevationMode = function(propId, elevationModeString) {
+    this.setElevationMode = (propId, elevationModeString) => {
         _propsApi_setElevationMode = _propsApi_setElevationMode || cwrap("propsApi_setElevationMode", null, ["number", "number", "number"]);
         var elevationModeInt = getElevationModeInt(elevationModeString);
         _propsApi_setElevationMode(_emscriptenApiPointer, propId, elevationModeInt);
     };
 
-    this.setGeometryId = function(propId, geometryId) {
+    this.setGeometryId = (propId, geometryId) => {
         _propsApi_setGeometryId = _propsApi_setGeometryId || cwrap("propsApi_setGeometryId", null, ["number", "number", "string"]);
         _propsApi_setGeometryId(_emscriptenApiPointer, propId, geometryId);
     };
 
-    this.setHeadingDegrees = function(propId, headingDegrees) {
+    this.setHeadingDegrees = (propId, headingDegrees) => {
         _propsApi_setHeadingDegrees = _propsApi_setHeadingDegrees || cwrap("propsApi_setHeadingDegrees", null, ["number", "number", "number", "number"]);
         _propsApi_setHeadingDegrees(_emscriptenApiPointer, propId, headingDegrees);
     };
 
-    this.setAutomaticIndoorMapPopulationEnabled = function(enabled) {
+    this.setAutomaticIndoorMapPopulationEnabled = (enabled) => {
         _propsApi_setAutomaticIndoorMapPopulationEnabled = _propsApi_setAutomaticIndoorMapPopulationEnabled || cwrap("propsApi_setAutomaticIndoorMapPopulationEnabled", null, ["number", "number"]);
         _propsApi_setAutomaticIndoorMapPopulationEnabled(_emscriptenApiPointer, enabled);
     };
 
-    this.isAutomaticIndoorMapPopulationEnabled = function() {
+    this.isAutomaticIndoorMapPopulationEnabled = () => {
         _propsApi_isAutomaticIndoorMapPopulationEnabled = _propsApi_isAutomaticIndoorMapPopulationEnabled || cwrap("propsApi_isAutomaticIndoorMapPopulationEnabled", "number", ["number"]);
         return _propsApi_isAutomaticIndoorMapPopulationEnabled(_emscriptenApiPointer);
     };
 
-    this.tryGetIndoorMapEntitySetProps = function(indoorMapId, floorId) {
+    this.tryGetIndoorMapEntitySetProps = (indoorMapId, floorId) => {
         _propsApi_getIndoorMapPropCount = _propsApi_getIndoorMapPropCount || cwrap("propsApi_getIndoorMapPropCount", "number", ["number", "string", "number"]);
         var propCount = _propsApi_getIndoorMapPropCount(_emscriptenApiPointer, indoorMapId, floorId);
 
@@ -162,13 +161,13 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
         _propsApi_tryGetIndoorMapPropDataBufferSizes = _propsApi_tryGetIndoorMapPropDataBufferSizes || cwrap("propsApi_tryGetIndoorMapPropDataBufferSizes", "number", ["number", "string", "number", "number", "number", "number", "number"]);
 
         var success = _propsApi_tryGetIndoorMapPropDataBufferSizes(
-                        _emscriptenApiPointer,
-                        indoorMapId, 
-                        floorId,
-                        propCount,
-                        indoorMapPerPropNameSizesBuf.ptr,
-                        indoorMapPerPropModelSizesBuf.ptr,
-                        indoorMapPropBufferSizesBuf.ptr);
+            _emscriptenApiPointer,
+            indoorMapId,
+            floorId,
+            propCount,
+            indoorMapPerPropNameSizesBuf.ptr,
+            indoorMapPerPropModelSizesBuf.ptr,
+            indoorMapPropBufferSizesBuf.ptr);
 
         if (!success) {
             return null;
@@ -191,7 +190,7 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
 
         success = _propsApi_tryGetIndoorMapPropData(
             _emscriptenApiPointer,
-            indoorMapId, 
+            indoorMapId,
             floorId,
             propCount,
             indoorMapPropStringNamesBuf.ptr,
@@ -226,8 +225,8 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
             var model = indoorMapPropStringModels.slice(modelBufferHead, modelBufferEnd);
             modelBufferHead = modelBufferEnd;
 
-            var posLat = indoorMapPropLatLngs[2*i];
-            var posLng = indoorMapPropLatLngs[2*i + 1];
+            var posLat = indoorMapPropLatLngs[2 * i];
+            var posLng = indoorMapPropLatLngs[2 * i + 1];
             var position = L.latLng(posLat, posLng);
 
             var height = indoorMapPropHeights[i];
@@ -240,28 +239,28 @@ function EmscriptenPropsApi(emscriptenApiPointer, cwrap, emscriptenModule, emscr
         return indoorMapEntityPropList;
     };
 
-    this.setIndoorMapPopulationServiceUrl = function(serviceUrl) {
+    this.setIndoorMapPopulationServiceUrl = (serviceUrl) => {
         _propsApi_setIndoorMapPopulationServiceUrl = _propsApi_setIndoorMapPopulationServiceUrl || cwrap("propsApi_setIndoorMapPopulationServiceUrl", null, ["number", "string"]);
         _propsApi_setIndoorMapPopulationServiceUrl(_emscriptenApiPointer, serviceUrl);
     };
 
-    var indoorMapEntitySetPropsLoadedHandler = function(indoorMapIdPtr, floorId) {
+    var indoorMapEntitySetPropsLoadedHandler = (indoorMapIdPtr, floorId) => {
         if (_indoorMapEntitySetPropsLoadedCallback !== null) {
             var indoorMapId = _emscriptenMemory.stringifyPointer(indoorMapIdPtr);
             _indoorMapEntitySetPropsLoadedCallback(indoorMapId, floorId);
         }
     };
 
-    this.setIndoorMapEntitySetPropsLoadedCallback = function(callback) {
+    this.setIndoorMapEntitySetPropsLoadedCallback = (callback) => {
         _indoorMapEntitySetPropsLoadedCallback = callback;
     };
 
-    this.registerIndoorMapEntitySetPropsLoadedHandler = function(callback) {
+    this.registerIndoorMapEntitySetPropsLoadedHandler = (callback) => {
         _propsApi_setIndoorMapEntitySetPropsLoadedCallback = _propsApi_setIndoorMapEntitySetPropsLoadedCallback || cwrap("propsApi_setIndoorMapEntitySetPropsLoadedCallback", null, ["number", "number"]);
         _propsApi_setIndoorMapEntitySetPropsLoadedCallback(_emscriptenApiPointer, emscriptenModule.addFunction(callback));
     };
 
-    this.setIndoorMapPopulationRequestCompletedCallback = function(callback) {
+    this.setIndoorMapPopulationRequestCompletedCallback = (callback) => {
         _propsApi_setIndoorMapPopulationRequestCompletedCallback = _propsApi_setIndoorMapPopulationRequestCompletedCallback || cwrap("propsApi_setIndoorMapPopulationRequestCompletedCallback", null, ["number", "number", "number"]);
         _propsApi_setIndoorMapPopulationRequestCompletedCallback(_emscriptenApiPointer, emscriptenModule.addFunction(callback));
     };

--- a/src/private/emscripten_api/emscripten_rendering_api.js
+++ b/src/private/emscripten_api/emscripten_rendering_api.js
@@ -1,7 +1,7 @@
 import { Vector3 } from "../../public/space";
 import { colorToRgba32 } from "./emscripten_interop_utils.js";
 
-function EmscriptenRenderingApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenRenderingApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -15,54 +15,54 @@ function EmscriptenRenderingApi(emscriptenApiPointer, cwrap, emscriptenModule, e
     var _renderingApi_GetNorthFacingOrientationMatrix = cwrap("renderingApi_GetNorthFacingOrientationMatrix", null, ["number", "number", "number", "number", "number"]);
 
 
-    this.setMapCollapsed = function(isMapCollapsed) {
+    this.setMapCollapsed = (isMapCollapsed) => {
         _renderingApi_SetMapCollapsed(_emscriptenApiPointer, isMapCollapsed ? 1 : 0);
     };
 
-    this.setClearColor = function(clearColor) {
+    this.setClearColor = (clearColor) => {
         var clearColorRGBA32 = colorToRgba32(clearColor);
         _renderingApi_SetClearColor(_emscriptenApiPointer, clearColorRGBA32);
     };
 
-    this.getCameraRelativePosition = function(latLng) {
+    this.getCameraRelativePosition = (latLng) => {
         var renderPosition = new Array(3);
-        _emscriptenMemory.passDoubles(renderPosition, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(renderPosition, (resultArray, arraySize) => {
             _renderingApi_GetCameraRelativePosition(_emscriptenApiPointer, latLng.lat, latLng.lng, latLng.alt || 0.0, arraySize, resultArray);
             renderPosition = _emscriptenMemory.readDoubles(resultArray, arraySize);
         });
         return new Vector3(renderPosition);
     };
 
-    this.getNorthFacingOrientationMatrix = function(latLng) {
+    this.getNorthFacingOrientationMatrix = (latLng) => {
         var orientation = new Array(16);
-        _emscriptenMemory.passDoubles(orientation, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(orientation, (resultArray, arraySize) => {
             _renderingApi_GetNorthFacingOrientationMatrix(_emscriptenApiPointer, latLng.lat, latLng.lng, arraySize, resultArray);
             orientation = _emscriptenMemory.readDoubles(resultArray, arraySize);
         });
         return orientation;
     };
 
-    this.getCameraProjectionMatrix = function() {
+    this.getCameraProjectionMatrix = () => {
         var projection = new Array(16);
-        _emscriptenMemory.passDoubles(projection, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(projection, (resultArray, arraySize) => {
             _renderingApi_GetCameraProjectionMatrix(_emscriptenApiPointer, arraySize, resultArray);
             projection = _emscriptenMemory.readDoubles(resultArray, arraySize);
         });
         return projection;
     };
 
-    this.getCameraOrientationMatrix = function() {
+    this.getCameraOrientationMatrix = () => {
         var orientation = new Array(16);
-        _emscriptenMemory.passDoubles(orientation, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(orientation, (resultArray, arraySize) => {
             _renderingApi_GetCameraOrientationMatrix(_emscriptenApiPointer, arraySize, resultArray);
             orientation = _emscriptenMemory.readDoubles(resultArray, arraySize);
         });
         return orientation;
     };
 
-    this.getLightingData = function() {
+    this.getLightingData = () => {
         var lightingData = new Array(21);
-        _emscriptenMemory.passDoubles(lightingData, function (resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(lightingData, (resultArray, arraySize) => {
             _renderingApi_GetLightingData(_emscriptenApiPointer, arraySize, resultArray);
             lightingData = _emscriptenMemory.readDoubles(resultArray, arraySize);
         });

--- a/src/private/emscripten_api/emscripten_rendering_api.js
+++ b/src/private/emscripten_api/emscripten_rendering_api.js
@@ -1,5 +1,5 @@
-var space = require("../../public/space");
-var interopUtils = require("./emscripten_interop_utils.js");
+import { Vector3 } from "../../public/space";
+import { colorToRgba32 } from "./emscripten_interop_utils.js";
 
 function EmscriptenRenderingApi(emscriptenApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
@@ -20,7 +20,7 @@ function EmscriptenRenderingApi(emscriptenApiPointer, cwrap, emscriptenModule, e
     };
 
     this.setClearColor = function(clearColor) {
-        var clearColorRGBA32 = interopUtils.colorToRgba32(clearColor);
+        var clearColorRGBA32 = colorToRgba32(clearColor);
         _renderingApi_SetClearColor(_emscriptenApiPointer, clearColorRGBA32);
     };
 
@@ -30,7 +30,7 @@ function EmscriptenRenderingApi(emscriptenApiPointer, cwrap, emscriptenModule, e
             _renderingApi_GetCameraRelativePosition(_emscriptenApiPointer, latLng.lat, latLng.lng, latLng.alt || 0.0, arraySize, resultArray);
             renderPosition = _emscriptenMemory.readDoubles(resultArray, arraySize);
         });
-        return new space.Vector3(renderPosition);
+        return new Vector3(renderPosition);
     };
 
     this.getNorthFacingOrientationMatrix = function(latLng) {
@@ -69,23 +69,23 @@ function EmscriptenRenderingApi(emscriptenApiPointer, cwrap, emscriptenModule, e
 
         var lighting = {
             key: {
-                direction: new space.Vector3(lightingData[0], lightingData[1], lightingData[2]),
-                color: new space.Vector3(lightingData[9], lightingData[10], lightingData[11])
+                direction: new Vector3(lightingData[0], lightingData[1], lightingData[2]),
+                color: new Vector3(lightingData[9], lightingData[10], lightingData[11])
             },
             back: {
-                direction: new space.Vector3(lightingData[3], lightingData[4], lightingData[5]),
-                color: new space.Vector3(lightingData[12], lightingData[13], lightingData[14])
+                direction: new Vector3(lightingData[3], lightingData[4], lightingData[5]),
+                color: new Vector3(lightingData[12], lightingData[13], lightingData[14])
             },
             fill: {
-                direction: new space.Vector3(lightingData[6], lightingData[7], lightingData[8]),
-                color: new space.Vector3(lightingData[15], lightingData[16], lightingData[17])
+                direction: new Vector3(lightingData[6], lightingData[7], lightingData[8]),
+                color: new Vector3(lightingData[15], lightingData[16], lightingData[17])
             },
             ambient: {
-                color: new space.Vector3(lightingData[18], lightingData[19], lightingData[20])
+                color: new Vector3(lightingData[18], lightingData[19], lightingData[20])
             }
         };
         return lighting;
     };
 }
 
-module.exports = EmscriptenRenderingApi;
+export default EmscriptenRenderingApi;

--- a/src/private/emscripten_api/emscripten_spaces_api.js
+++ b/src/private/emscripten_api/emscripten_spaces_api.js
@@ -1,6 +1,6 @@
 import { Vector3 } from "../../public/space";
 
-function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
+export function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
     var _eegeoApiPointer = eegeoApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -16,21 +16,21 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
     var _spacesApi_ScreenPointToRay = cwrap("spacesApi_ScreenPointToRay", null, ["number", "number", "number", "number"]);
     var _spacesApi_LatLongToVerticallyDownRay = cwrap("spacesApi_LatLongToVerticallyDownRay", null, ["number", "number", "number", "number"]);
 
-    var _worldToScreen = function(lat, long, alt) {
+    var _worldToScreen = (lat, long, alt) => {
         _worldToScreenWrap = _worldToScreenWrap || cwrap("worldToScreen", null, ["number", "number", "number", "number", "number"]);
 
         var screenPos = [0, 0, 0];
-        _emscriptenMemory.passDoubles(screenPos, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(screenPos, function (resultArray, arraySize) {
             _worldToScreenWrap(_eegeoApiPointer, lat, long, alt, resultArray);
             screenPos = _emscriptenMemory.readDoubles(resultArray, 3);
         });
         return new Vector3(screenPos);
     };
 
-    var _screenToLatLng = function(screenX, screenY, raycastFunc) {
+    var _screenToLatLng = (screenX, screenY, raycastFunc) => {
         var latLngAltArray = [0, 0, 0];
         var foundWorldPoint = false;
-        _emscriptenMemory.passDoubles(latLngAltArray, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(latLngAltArray, function (resultArray, arraySize) {
             var success = raycastFunc(_eegeoApiPointer, screenX, screenY, resultArray);
             foundWorldPoint = !!success;
             latLngAltArray = _emscriptenMemory.readDoubles(resultArray, 3);
@@ -38,26 +38,26 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
         return (foundWorldPoint) ? L.latLng(latLngAltArray) : null;
     };
 
-    var _screenToTerrainPoint = function(screenX, screenY) {
+    var _screenToTerrainPoint = (screenX, screenY) => {
         _screenToTerrainPointWrap = _screenToTerrainPointWrap || cwrap("screenToTerrainPoint", "number", ["number", "number", "number", "number"]);
         return _screenToLatLng(screenX, screenY, _screenToTerrainPointWrap);
     };
 
-    var _screenToIndoorPoint = function(screenX, screenY) {
+    var _screenToIndoorPoint = (screenX, screenY) => {
         _screenToIndoorPointWrap = _screenToIndoorPointWrap || cwrap("screenToIndoorPoint", "number", ["number", "number", "number", "number"]);
         return _screenToLatLng(screenX, screenY, _screenToIndoorPointWrap);
     };
 
-    var _getAltitudeAtLatLng = function(lat, long) {
+    var _getAltitudeAtLatLng = (lat, long) => {
         _getAltitudeAtLatLngWrap = _getAltitudeAtLatLngWrap || cwrap("getAltitudeAtLatLng", "number", ["number", "number", "number"]);
         return _getAltitudeAtLatLngWrap(_eegeoApiPointer, lat, long);
     };
 
-    var _getUpdatedAltitudeAtLatLng = function(lat, long, previousHeight, previousLevel) {
+    var _getUpdatedAltitudeAtLatLng = (lat, long, previousHeight, previousLevel) => {
         _getUpdatedAltitudeAtLatLngWrap = _getUpdatedAltitudeAtLatLngWrap || cwrap("getUpdatedAltitudeAtLatLng", "number", ["number", "number", "number", "number", "number", "number"]);
         var results = [0, 0];
         var altitudeUpdated = false;
-        _emscriptenMemory.passDoubles(results, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(results, (resultArray, arraySize) => {
             var success = _getUpdatedAltitudeAtLatLngWrap(_eegeoApiPointer, lat, long, previousHeight, previousLevel, resultArray);
             altitudeUpdated = !!success;
             if (altitudeUpdated) {
@@ -67,24 +67,24 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
         return altitudeUpdated ? results : null;
     };
 
-    var _getMortonKeyAtLatLng = function(lat, long) {
+    var _getMortonKeyAtLatLng = (lat, long) => {
         _getMortonKeyAtLatLngWrap = _getMortonKeyAtLatLngWrap || cwrap("getMortonKeyAtLatLng", null, ["number", "number", "number"]);
         var mortonKey = "";
-        _emscriptenMemory.passString(mortonKey, function(resultString){
+        _emscriptenMemory.passString(mortonKey, (resultString) => {
             _getMortonKeyAtLatLngWrap(lat, long, resultString);
             mortonKey = _emscriptenMemory.stringifyPointer(resultString);
         });
         return mortonKey;
     };
 
-    var _getMortonKeyCenter = function(mortonKey) {
+    var _getMortonKeyCenter = (mortonKey) => {
         _getMortonKeyCenterWrap = _getMortonKeyCenterWrap || cwrap("getMortonKeyCenter", null, ["string", "number"]);
         var latLngCenterArray = [0, 0];
-        _emscriptenMemory.passDoubles(latLngCenterArray, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(latLngCenterArray, (resultArray, arraySize) => {
             _getMortonKeyCenterWrap(mortonKey, resultArray);
             latLngCenterArray = _emscriptenMemory.readDoubles(resultArray, 2);
         });
-        latLngCenterArray.forEach(function(value, index) {
+        latLngCenterArray.forEach((value, index) => {
             if (isNaN(value)) {
                 latLngCenterArray[index] = 0;
             }
@@ -92,14 +92,14 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
         return L.latLng(latLngCenterArray);
     };
 
-    var _getMortonKeyCorners = function(mortonKey, insetMeters) {
+    var _getMortonKeyCorners = (mortonKey, insetMeters) => {
         _getMortonKeyCornersWrap = _getMortonKeyCornersWrap || cwrap("getMortonKeyCorners", null, ["string", "number", "number"]);
         var latLngCornersArray = [0, 0, 0, 0, 0, 0, 0, 0];
-        _emscriptenMemory.passDoubles(latLngCornersArray, function(resultArray, arraySize) {
+        _emscriptenMemory.passDoubles(latLngCornersArray, (resultArray, arraySize) => {
             _getMortonKeyCornersWrap(mortonKey, insetMeters, resultArray);
             latLngCornersArray = _emscriptenMemory.readDoubles(resultArray, 8);
         });
-        latLngCornersArray.forEach(function(value, index) {
+        latLngCornersArray.forEach((value, index) => {
             if (isNaN(value)) {
                 latLngCornersArray[index] = 0;
             }
@@ -112,36 +112,35 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
         ];
     };
 
-    this.worldToScreen = function(position) {
+    this.worldToScreen = (position) => {
         var point = L.latLng(position);
         return _worldToScreen(point.lat, point.lng, point.alt || 0);
     };
 
-    this.screenToTerrainPoint = function(screenPoint) {
+    this.screenToTerrainPoint = (screenPoint) => {
         var point = L.point(screenPoint);
         return _screenToTerrainPoint(point.x, point.y);
     };
 
-    this.screenToIndoorPoint = function(screenPoint) {
+    this.screenToIndoorPoint = (screenPoint) => {
         var point = L.point(screenPoint);
         return _screenToIndoorPoint(point.x, point.y);
     };
 
-    this.screenToWorldPoint = function(screenPoint) {
+    this.screenToWorldPoint = (screenPoint) => {
         return this.screenToIndoorPoint(screenPoint) || this.screenToTerrainPoint(screenPoint);
     };
 
-    this.getAltitudeAtLatLng = function(latLng) {
+    this.getAltitudeAtLatLng = (latLng) => {
         latLng = L.latLng(latLng);
         return _getAltitudeAtLatLng(latLng.lat, latLng.lng);
     };
 
-    this.getUpdatedAltitudeAtLatLng = function(latLng, previousHeight, previousLevel) {
-        return _getUpdatedAltitudeAtLatLng(latLng.lat, latLng.lng, previousHeight, previousLevel);
-    };
+    this.getUpdatedAltitudeAtLatLng = (latLng, previousHeight, previousLevel) =>
+        _getUpdatedAltitudeAtLatLng(latLng.lat, latLng.lng, previousHeight, previousLevel);
 
 
-    this.screenPointToRay = function(screenPoint) {
+    this.screenPointToRay = (screenPoint) => {
         var point = L.point(screenPoint);
         var resultRayBuffer = _emscriptenMemory.createDoubleBuffer(6);
         _spacesApi_ScreenPointToRay(_eegeoApiPointer, point.x, point.y, resultRayBuffer.ptr);
@@ -154,7 +153,7 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
         };
     };
 
-    this.latLongToVerticallyDownRay = function(latLng) {
+    this.latLongToVerticallyDownRay = (latLng) => {
         var resultRayBuffer = _emscriptenMemory.createDoubleBuffer(6);
         _spacesApi_LatLongToVerticallyDownRay(_eegeoApiPointer, latLng.lat, latLng.lng, resultRayBuffer.ptr);
         var resultArray = _emscriptenMemory.consumeBufferToArray(resultRayBuffer);
@@ -166,18 +165,14 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
         };
     };
 
-    this.getMortonKeyAtLatLng = function(latLng) {
+    this.getMortonKeyAtLatLng = (latLng) => {
         var _latLng = L.latLng(latLng);
         return _getMortonKeyAtLatLng(_latLng.lat, _latLng.lng);
     };
 
-    this.getMortonKeyCenter = function(mortonKey) {
-        return _getMortonKeyCenter(mortonKey);
-    };
+    this.getMortonKeyCenter = (mortonKey) => _getMortonKeyCenter(mortonKey);
 
-    this.getMortonKeyCorners = function(mortonKey, insetMeters) {
-        return _getMortonKeyCorners(mortonKey, insetMeters || 0.0);
-    };
+    this.getMortonKeyCorners = (mortonKey, insetMeters) => _getMortonKeyCorners(mortonKey, insetMeters || 0.0);
 }
 
 export default EmscriptenSpacesApi;

--- a/src/private/emscripten_api/emscripten_spaces_api.js
+++ b/src/private/emscripten_api/emscripten_spaces_api.js
@@ -1,4 +1,4 @@
-var space = require("../../public/space");
+import { Vector3 } from "../../public/space";
 
 function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscriptenMemory) {
 
@@ -24,7 +24,7 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
             _worldToScreenWrap(_eegeoApiPointer, lat, long, alt, resultArray);
             screenPos = _emscriptenMemory.readDoubles(resultArray, 3);
         });
-        return new space.Vector3(screenPos);
+        return new Vector3(screenPos);
     };
 
     var _screenToLatLng = function(screenX, screenY, raycastFunc) {
@@ -146,8 +146,8 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
         var resultRayBuffer = _emscriptenMemory.createDoubleBuffer(6);
         _spacesApi_ScreenPointToRay(_eegeoApiPointer, point.x, point.y, resultRayBuffer.ptr);
         var resultArray = _emscriptenMemory.consumeBufferToArray(resultRayBuffer);
-        var rayOrigin = new space.Vector3(resultArray[0], resultArray[1], resultArray[2]);
-        var rayDirection = new space.Vector3(resultArray[3], resultArray[4], resultArray[5]);
+        var rayOrigin = new Vector3(resultArray[0], resultArray[1], resultArray[2]);
+        var rayDirection = new Vector3(resultArray[3], resultArray[4], resultArray[5]);
         return {
             origin: rayOrigin,
             direction: rayDirection
@@ -158,8 +158,8 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
         var resultRayBuffer = _emscriptenMemory.createDoubleBuffer(6);
         _spacesApi_LatLongToVerticallyDownRay(_eegeoApiPointer, latLng.lat, latLng.lng, resultRayBuffer.ptr);
         var resultArray = _emscriptenMemory.consumeBufferToArray(resultRayBuffer);
-        var rayOrigin = new space.Vector3(resultArray[0], resultArray[1], resultArray[2]);
-        var rayDirection = new space.Vector3(resultArray[3], resultArray[4], resultArray[5]);
+        var rayOrigin = new Vector3(resultArray[0], resultArray[1], resultArray[2]);
+        var rayDirection = new Vector3(resultArray[3], resultArray[4], resultArray[5]);
         return {
             origin: rayOrigin,
             direction: rayDirection
@@ -180,4 +180,4 @@ function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, emscripte
     };
 }
 
-module.exports = EmscriptenSpacesApi;
+export default EmscriptenSpacesApi;

--- a/src/private/emscripten_api/emscripten_themes_api.js
+++ b/src/private/emscripten_api/emscripten_themes_api.js
@@ -27,4 +27,4 @@ function EmscriptenThemesApi(eegeoApiPointer, cwrap, emscriptenModule) {
     };
 }
 
-module.exports = EmscriptenThemesApi;
+export default EmscriptenThemesApi;

--- a/src/private/emscripten_api/emscripten_themes_api.js
+++ b/src/private/emscripten_api/emscripten_themes_api.js
@@ -1,4 +1,4 @@
-function EmscriptenThemesApi(eegeoApiPointer, cwrap, emscriptenModule) {
+export function EmscriptenThemesApi(eegeoApiPointer, cwrap, emscriptenModule) {
 
     var _eegeoApiPointer = eegeoApiPointer;
     var _setTheme = null;
@@ -6,22 +6,22 @@ function EmscriptenThemesApi(eegeoApiPointer, cwrap, emscriptenModule) {
     var _setThemeManifest = null;
     var _setCallback = null;
 
-    this.setTheme = function(themeName) {
+    this.setTheme = (themeName) => {
         _setTheme = _setTheme || cwrap("setTheme", null, ["number", "string"]);
         _setTheme(_eegeoApiPointer, themeName);
     };
 
-    this.setState = function(stateName, transitionTime) {
+    this.setState = (stateName, transitionTime) => {
         _setState = _setState || cwrap("setState", null, ["number", "string", "number"]);
-    	_setState(_eegeoApiPointer, stateName, transitionTime);
+        _setState(_eegeoApiPointer, stateName, transitionTime);
     };
 
-    this.setThemeManifest = function(themeManifest) {
+    this.setThemeManifest = (themeManifest) => {
         _setThemeManifest = _setThemeManifest || cwrap("setThemeManifest", null, ["number", "string"]);
         _setThemeManifest(_eegeoApiPointer, themeManifest);
     };
 
-    this.registerStreamingCompletedCallback = function (callback) {
+    this.registerStreamingCompletedCallback = (callback) => {
         _setCallback = _setCallback || cwrap("setStreamingCompletedCallback", null, ["number", "number"]);
         _setCallback(_eegeoApiPointer, emscriptenModule.addFunction(callback));
     };

--- a/src/private/emscripten_api/emscripten_version_api.js
+++ b/src/private/emscripten_api/emscripten_version_api.js
@@ -41,4 +41,4 @@ function EmscriptenVersionApi(emscriptenApiPointer, cwrap, emscriptenMemory) {
     };
 }
 
-module.exports = EmscriptenVersionApi;
+export default EmscriptenVersionApi;

--- a/src/private/emscripten_api/emscripten_version_api.js
+++ b/src/private/emscripten_api/emscripten_version_api.js
@@ -1,4 +1,4 @@
-function EmscriptenVersionApi(emscriptenApiPointer, cwrap, emscriptenMemory) {
+export function EmscriptenVersionApi(emscriptenApiPointer, cwrap, emscriptenMemory) {
 
     var _emscriptenApiPointer = emscriptenApiPointer;
     var _emscriptenMemory = emscriptenMemory;
@@ -9,14 +9,14 @@ function EmscriptenVersionApi(emscriptenApiPointer, cwrap, emscriptenMemory) {
     var _versionApi_GetPlatformHashStringSize = cwrap("versionApi_GetPlatformHashStringSize", "number", ["number"]);
     var _versionApi_TryGetPlatformHashString = cwrap("versionApi_TryGetPlatformHashString", "number", ["number", "number", "number"]);
 
-    var _tryGetNativeVersionString = function(nativeGetBufferSizeFunc, nativeGetStringFunc) {
+    var _tryGetNativeVersionString = (nativeGetBufferSizeFunc, nativeGetStringFunc) => {
         var bufferSize = nativeGetBufferSizeFunc(_emscriptenApiPointer);
         var stringBuffer = _emscriptenMemory.createInt8Buffer(bufferSize);
         var success = nativeGetStringFunc(
             _emscriptenApiPointer,
             stringBuffer.ptr,
             bufferSize
-            );
+        );
 
         if (!success) {
             return null;
@@ -26,19 +26,15 @@ function EmscriptenVersionApi(emscriptenApiPointer, cwrap, emscriptenMemory) {
         return stringValue;
     };
 
-    this.getPlatformVersion = function() {
-        return _tryGetNativeVersionString(
-            _versionApi_GetPlatformVersionStringSize,
-            _versionApi_TryGetPlatformVersionString
-            );
-    };
+    this.getPlatformVersion = () => _tryGetNativeVersionString(
+        _versionApi_GetPlatformVersionStringSize,
+        _versionApi_TryGetPlatformVersionString
+    );
 
-    this.getPlatformVersionHash = function() {
-        return _tryGetNativeVersionString(
-            _versionApi_GetPlatformHashStringSize,
-            _versionApi_TryGetPlatformHashString
-            );
-    };
+    this.getPlatformVersionHash = () => _tryGetNativeVersionString(
+        _versionApi_GetPlatformHashStringSize,
+        _versionApi_TryGetPlatformHashString
+    );
 }
 
 export default EmscriptenVersionApi;

--- a/src/private/events/map_move_events.js
+++ b/src/private/events/map_move_events.js
@@ -1,4 +1,4 @@
-const MapMoveEvents = function(leafletMap) {
+export function MapMoveEvents (leafletMap) {
 
     var _eventType = [
         "move",
@@ -23,16 +23,16 @@ const MapMoveEvents = function(leafletMap) {
         "transitionend"
     ];
 
-    var _onEvent = function(eventKey) {
+    var _onEvent = (eventKey) => {
         if (typeof _eventType[eventKey] === undefined) {
             return;
         }
         leafletMap.fire(_eventType[eventKey]);
     };
 
-    this.setEventCallbacks = function(cameraApi) {
+    this.setEventCallbacks = (cameraApi) => {
         cameraApi.setEventCallback(_onEvent);
     };
-};
+}
 
 export default MapMoveEvents;

--- a/src/private/events/map_move_events.js
+++ b/src/private/events/map_move_events.js
@@ -1,4 +1,4 @@
-var MapMoveEvents = function(leafletMap) {
+const MapMoveEvents = function(leafletMap) {
 
     var _eventType = [
         "move",
@@ -34,4 +34,5 @@ var MapMoveEvents = function(leafletMap) {
         cameraApi.setEventCallback(_onEvent);
     };
 };
-module.exports = MapMoveEvents;
+
+export default MapMoveEvents;

--- a/src/private/frame_rate_module.js
+++ b/src/private/frame_rate_module.js
@@ -1,6 +1,6 @@
 import MapModule from "./map_module";
 
-function FrameRateModule(
+export function FrameRateModule(
     emscriptenApi,
     targetVSyncInterval,
     throttledTargetFrameIntervalMilliseconds,
@@ -15,7 +15,7 @@ function FrameRateModule(
     var _throttleWhenIdleEnabled = throttleWhenIdleEnabled;
     var _ready = false;
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _emscriptenApi.frameRateApi.setTargetVSyncInterval(_targetVSyncInterval);
         _emscriptenApi.frameRateApi.setThrottledTargetFrameInterval(_throttledTargetFrameIntervalMilliseconds);
         _emscriptenApi.frameRateApi.setIdleSecondsBeforeThrottle(_idleSecondsBeforeThrottle);
@@ -23,11 +23,9 @@ function FrameRateModule(
         _ready = true;
     };
 
-    this.ready = function() {
-        return _ready;
-    };
+    this.ready = () => _ready;
 
-    this.setTargetVSyncInterval = function(targetVSyncInterval) {
+    this.setTargetVSyncInterval = (targetVSyncInterval) => {
         _targetVSyncInterval = targetVSyncInterval;
         if (!_ready) {
             return;
@@ -35,7 +33,7 @@ function FrameRateModule(
         _emscriptenApi.frameRateApi.setTargetVSyncInterval(_targetVSyncInterval);
     };
 
-    this.setThrottledTargetFrameInterval = function(throttledTargetFrameIntervalMilliseconds) {
+    this.setThrottledTargetFrameInterval = (throttledTargetFrameIntervalMilliseconds) => {
         _throttledTargetFrameIntervalMilliseconds = throttledTargetFrameIntervalMilliseconds;
         if (!_ready) {
             return;
@@ -43,7 +41,7 @@ function FrameRateModule(
         _emscriptenApi.frameRateApi.setThrottledTargetFrameInterval(_throttledTargetFrameIntervalMilliseconds);
     };
 
-    this.setIdleSecondsBeforeThrottle = function(idleSecondsBeforeThrottle) {
+    this.setIdleSecondsBeforeThrottle = (idleSecondsBeforeThrottle) => {
         _idleSecondsBeforeThrottle = idleSecondsBeforeThrottle;
         if (!_ready) {
             return;
@@ -51,7 +49,7 @@ function FrameRateModule(
         _emscriptenApi.frameRateApi.setIdleSecondsBeforeThrottle(_idleSecondsBeforeThrottle);
     };
 
-    this.setThrottleWhenIdleEnabled = function(throttleWhenIdleEnabled) {
+    this.setThrottleWhenIdleEnabled = (throttleWhenIdleEnabled) => {
         _throttleWhenIdleEnabled = throttleWhenIdleEnabled;
         if (!_ready) {
             return;
@@ -59,7 +57,7 @@ function FrameRateModule(
         _emscriptenApi.frameRateApi.setThrottleWhenIdleEnabled(_throttleWhenIdleEnabled);
     };
 
-    this.cancelThrottle = function() {
+    this.cancelThrottle = () => {
         // don't attempt to defer command if called during startup
         if (!_ready) {
             return;

--- a/src/private/frame_rate_module.js
+++ b/src/private/frame_rate_module.js
@@ -1,5 +1,4 @@
-var MapModule = require("./map_module");
-
+import MapModule from "./map_module";
 
 function FrameRateModule(
     emscriptenApi,
@@ -68,6 +67,7 @@ function FrameRateModule(
         _emscriptenApi.frameRateApi.cancelThrottle();
     };
 }
+
 FrameRateModule.prototype = MapModule;
 
-module.exports = FrameRateModule;
+export default FrameRateModule;

--- a/src/private/heatmap_module.js
+++ b/src/private/heatmap_module.js
@@ -1,6 +1,6 @@
 import MapModule from "./map_module";
 
-function HeatmapModule(emscriptenApi) {
+export function HeatmapModule(emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _heatmapIdToHeatmap = {};
@@ -8,20 +8,20 @@ function HeatmapModule(emscriptenApi) {
     var _ready = false;
 
 
-    var _createPendingHeatmaps = function() {
-        _pendingHeatmaps.forEach(function(heatmap) {
+    var _createPendingHeatmaps = () => {
+        _pendingHeatmaps.forEach(function (heatmap) {
             _createAndAdd(heatmap);
         });
         _pendingHeatmaps = [];
     };
 
-    var _createAndAdd = function(heatmap) {
+    var _createAndAdd = (heatmap) => {
         var heatmapId = _emscriptenApi.heatmapApi.createHeatmap(heatmap);
         _heatmapIdToHeatmap[heatmapId] = heatmap;
         return heatmapId;
     };
 
-    this.addHeatmap = function(heatmap) {
+    this.addHeatmap = (heatmap) => {
         if (_ready) {
             _createAndAdd(heatmap);
         }
@@ -30,7 +30,7 @@ function HeatmapModule(emscriptenApi) {
         }
     };
 
-    this.removeHeatmap = function(heatmap) {
+    this.removeHeatmap = (heatmap) => {
 
         if (!_ready) {
             var index = _pendingHeatmaps.indexOf(heatmap);
@@ -40,10 +40,7 @@ function HeatmapModule(emscriptenApi) {
             return;
         }
 
-        var heatmapId = Object.keys(_heatmapIdToHeatmap).find(function(key) {
-                return _heatmapIdToHeatmap[key] === heatmap;
-            }
-        );
+        var heatmapId = Object.keys(_heatmapIdToHeatmap).find((key) => _heatmapIdToHeatmap[key] === heatmap);
 
         if (heatmapId === undefined) {
             return;
@@ -53,16 +50,16 @@ function HeatmapModule(emscriptenApi) {
         delete _heatmapIdToHeatmap[heatmapId];
     };
 
-    this.onUpdate = function() {
+    this.onUpdate = () => {
         if (_ready) {
-            Object.keys(_heatmapIdToHeatmap).forEach(function(heatmapId) {
-                var heatmap = _heatmapIdToHeatmap[heatmapId];
-                _emscriptenApi.heatmapApi.updateNativeState(heatmapId, heatmap);
-            });
+            Object.keys(_heatmapIdToHeatmap).forEach((heatmapId) => {
+                    var heatmap = _heatmapIdToHeatmap[heatmapId];
+                    _emscriptenApi.heatmapApi.updateNativeState(heatmapId, heatmap);
+                });
         }
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
         _createPendingHeatmaps();
     };

--- a/src/private/heatmap_module.js
+++ b/src/private/heatmap_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 function HeatmapModule(emscriptenApi) {
 
@@ -67,6 +67,7 @@ function HeatmapModule(emscriptenApi) {
         _createPendingHeatmaps();
     };
 }
+
 HeatmapModule.prototype = MapModule;
 
-module.exports = HeatmapModule;
+export default HeatmapModule;

--- a/src/private/html_map_container.js
+++ b/src/private/html_map_container.js
@@ -1,4 +1,4 @@
-var HTMLMapContainer = function(browserDocument, browserWindow, parentElement, canvasId, canvasWidth, canvasHeight, backgroundColor, containerId, mapId) {
+export const HTMLMapContainer = function(browserDocument, browserWindow, parentElement, canvasId, canvasWidth, canvasHeight, backgroundColor, containerId, mapId) {
 
     var _browserWindow = browserWindow;
     var _browserDocument = browserDocument;
@@ -190,4 +190,4 @@ var LoadingSpinner = function(browserWindow, domElement) {
     };
 };
 
-module.exports = HTMLMapContainer;
+export default HTMLMapContainer;

--- a/src/private/html_map_container.js
+++ b/src/private/html_map_container.js
@@ -1,9 +1,9 @@
-export const HTMLMapContainer = function(browserDocument, browserWindow, parentElement, canvasId, canvasWidth, canvasHeight, backgroundColor, containerId, mapId) {
+export function HTMLMapContainer (browserDocument, browserWindow, parentElement, canvasId, canvasWidth, canvasHeight, backgroundColor, containerId, mapId) {
 
     var _browserWindow = browserWindow;
     var _browserDocument = browserDocument;
 
-    var _createDOMElement = function(parentElement, tagName, attributes, style) {
+    var _createDOMElement = (parentElement, tagName, attributes, style) => {
         var element = _browserDocument.createElement(tagName);
         for (var attributeName in attributes) {
             element.setAttribute(attributeName, attributes[attributeName]);
@@ -15,7 +15,7 @@ export const HTMLMapContainer = function(browserDocument, browserWindow, parentE
         return element;
     };
 
-    var _createMapContainer = function(parentElement) {
+    var _createMapContainer = (parentElement) => {
         var attributes = {
             "class": "wrld-map-container",
             "id": containerId
@@ -37,7 +37,7 @@ export const HTMLMapContainer = function(browserDocument, browserWindow, parentE
         css.innerHTML = ".leaflet-dragging .wrld-map-container { cursor: move; cursor: -webkit-grabbing; cursor: -moz-grabbing; }";
         document.head.appendChild(css);
 
-        mapContainer.onmousedown = function(e) {
+        mapContainer.onmousedown = (e) => {
             // Prevent middle-mouse scrolling on Windows
             if (e.button === 1) {
                 return false;
@@ -52,8 +52,8 @@ export const HTMLMapContainer = function(browserDocument, browserWindow, parentE
         return mapContainer;
     };
 
-    var _createLeafletOverlay = function(parentElement) {
-        var attributes = {"class": "wrld-leaflet-overlay"};
+    var _createLeafletOverlay = (parentElement) => {
+        var attributes = { "class": "wrld-leaflet-overlay" };
         var style = {
             "position": "absolute",
             "overflow": "hidden",
@@ -65,8 +65,8 @@ export const HTMLMapContainer = function(browserDocument, browserWindow, parentE
         return _createDOMElement(parentElement, "div", attributes, style);
     };
 
-    var _createErrorMessage = function(parentElement, messageText) {
-        var attributes = {"class": "wrld-error-message"};
+    var _createErrorMessage = (parentElement, messageText) => {
+        var attributes = { "class": "wrld-error-message" };
         var style = {
             "position": "absolute",
             "left": "0px",
@@ -82,7 +82,7 @@ export const HTMLMapContainer = function(browserDocument, browserWindow, parentE
         return errorMessage;
     };
 
-    var _createCanvas = function(parentElement, canvasId, width, height, backgroundColor) {
+    var _createCanvas = (parentElement, canvasId, width, height, backgroundColor) => {
         var attributes = {
             "class": "wrld-map-canvas",
             "id": canvasId,
@@ -98,7 +98,7 @@ export const HTMLMapContainer = function(browserDocument, browserWindow, parentE
         return canvas;
     };
 
-    var _createLoadingSpinner = function(parentElement) {
+    var _createLoadingSpinner = (parentElement) => {
         var style = {
             "position": "absolute",
             "width": "18px",
@@ -109,7 +109,7 @@ export const HTMLMapContainer = function(browserDocument, browserWindow, parentE
         return _createDOMElement(parentElement, "div", {}, style);
     };
 
-    var _createIndoorMapWatermark = function(parentElement) {
+    var _createIndoorMapWatermark = (parentElement) => {
         var attributes = {
             "id": "wrld-indoor-map-watermark" + mapId,
             "class": "wrld-indoor-map-watermark",
@@ -139,38 +139,38 @@ export const HTMLMapContainer = function(browserDocument, browserWindow, parentE
     this.loadingSpinner = new LoadingSpinner(_browserWindow, this.loadingSpinnerIcon);
     this.loadingSpinner.startSpinning();
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         this.loadingSpinner.stopSpinning();
         this.loadingSpinnerIcon.parentNode.removeChild(this.loadingSpinnerIcon);
     };
 
-    this.onError = function(message) {
+    this.onError = (message) => {
         this.loadingSpinner.stopSpinning();
         _createErrorMessage(this.mapContainer, message);
     };
 
-    this.width = function() {
+    this.width = () => {
         return this.mapContainer.clientWidth;
     };
 
-    this.height = function() {
+    this.height = () => {
         return this.mapContainer.clientHeight;
     };
 
-    this.onRemove = function() {
+    this.onRemove = () => {
         if (this.mapContainer.parentElement) {
             this.mapContainer.parentElement.removeChild(this.mapContainer);
         }
     };
-};
+}
 
-var LoadingSpinner = function(browserWindow, domElement) {
+function LoadingSpinner (browserWindow, domElement) {
     var _browserWindow = browserWindow;
     var _domElement = domElement;
     var _speed = 360;
     var _spinning = false;
 
-    var spin = function(timestamp) {
+    var spin = (timestamp) => {
         if (!_spinning) {
             return;
         }
@@ -180,14 +180,14 @@ var LoadingSpinner = function(browserWindow, domElement) {
         _browserWindow.requestAnimationFrame(spin);
     };
 
-    this.startSpinning = function() {
+    this.startSpinning = () => {
         _spinning = true;
         spin();
     };
 
-    this.stopSpinning = function() {
+    this.stopSpinning = () => {
         _spinning = false;
     };
-};
+}
 
 export default HTMLMapContainer;

--- a/src/private/id_to_object_map.js
+++ b/src/private/id_to_object_map.js
@@ -1,4 +1,4 @@
-var IdToObjectMap = function() {
+export const IdToObjectMap = function() {
     var _objects = {};
 
     this.insertObject = function(id, object) {
@@ -33,4 +33,4 @@ var IdToObjectMap = function() {
     };
 };
 
-module.exports = IdToObjectMap;
+export default IdToObjectMap;

--- a/src/private/id_to_object_map.js
+++ b/src/private/id_to_object_map.js
@@ -1,4 +1,4 @@
-export const IdToObjectMap = function() {
+export function IdToObjectMap () {
     var _objects = {};
 
     this.insertObject = function(id, object) {
@@ -31,6 +31,6 @@ export const IdToObjectMap = function() {
             func(id, object);
         }
     };
-};
+}
 
 export default IdToObjectMap;

--- a/src/private/indoor_entrance_marker_updater.js
+++ b/src/private/indoor_entrance_marker_updater.js
@@ -1,4 +1,4 @@
-var markers = require("../public/marker");
+import { marker as _marker } from "../public/marker";
 
 var IndoorEntranceMarkerUpdater = function(map, indoorsModule) {
 
@@ -33,7 +33,7 @@ var IndoorEntranceMarkerUpdater = function(map, indoorsModule) {
 	};
 
 	var _createEntranceMarker = function(entrance) {
-		var marker = markers.marker(entrance.getLatLng(), {
+		var marker = _marker(entrance.getLatLng(), {
 			title: entrance.getIndoorMapName(),
 			icon: _entranceIcon
 		});
@@ -66,4 +66,4 @@ var IndoorEntranceMarkerUpdater = function(map, indoorsModule) {
 
 };
 
-module.exports = IndoorEntranceMarkerUpdater;
+export default IndoorEntranceMarkerUpdater;

--- a/src/private/indoor_entrance_marker_updater.js
+++ b/src/private/indoor_entrance_marker_updater.js
@@ -1,6 +1,6 @@
 import { marker as _marker } from "../public/marker";
 
-var IndoorEntranceMarkerUpdater = function(map, indoorsModule) {
+export function IndoorEntranceMarkerUpdater (map, indoorsModule) {
 
 	var _map = map;
 	var _indoorsModule = indoorsModule;
@@ -14,7 +14,7 @@ var IndoorEntranceMarkerUpdater = function(map, indoorsModule) {
 	    iconAnchor: [24, 48]
 	});
 
-	var _addEntranceMarker = function(event) {
+	var _addEntranceMarker = (event) => {
 		var entrance = event.entrance;
 		var id = entrance.getIndoorMapId();
 
@@ -23,7 +23,7 @@ var IndoorEntranceMarkerUpdater = function(map, indoorsModule) {
 		_entranceMarkers[id] = marker;
 	};
 
-	var _removeEntranceMarker = function(event) {
+	var _removeEntranceMarker = (event) => {
 		var entrance = event.entrance;
 		var id = entrance.getIndoorMapId();
 
@@ -32,22 +32,22 @@ var IndoorEntranceMarkerUpdater = function(map, indoorsModule) {
 		delete _entranceMarkers[id];
 	};
 
-	var _createEntranceMarker = function(entrance) {
+	var _createEntranceMarker = (entrance) => {
 		var marker = _marker(entrance.getLatLng(), {
 			title: entrance.getIndoorMapName(),
 			icon: _entranceIcon
 		});
-		marker.on("click", function() {
+		marker.on("click", function () {
 			_indoorsModule.enter(entrance);
 		});
 		return marker;
 	};
 
-	var _showEntranceMarkers = function() {
+	var _showEntranceMarkers = () => {
 		_map.addLayer(_layerGroup);
 	};
 
-	var _hideEntranceMarkers = function() {
+	var _hideEntranceMarkers = () => {
 		_map.removeLayer(_layerGroup);
 	};
 
@@ -59,11 +59,11 @@ var IndoorEntranceMarkerUpdater = function(map, indoorsModule) {
 	_indoorsModule.on("indoormapenter", _hideEntranceMarkers);
 	_indoorsModule.on("indoormapexit", _showEntranceMarkers);
 
-	this.removeAllEntranceMarkers = function() {
+	this.removeAllEntranceMarkers = () => {
 		_layerGroup.clearLayers();
 		_entranceMarkers = {};
 	};
 
-};
+}
 
 export default IndoorEntranceMarkerUpdater;

--- a/src/private/indoor_map_entity_information_module.js
+++ b/src/private/indoor_map_entity_information_module.js
@@ -1,6 +1,6 @@
 import MapModule from "./map_module";
 
-function IndoorMapEntityInformationModuleImpl(emscriptenApi) {
+export function IndoorMapEntityInformationModuleImpl(emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _nativeIdToIndoorMapEntityInformation = {};
@@ -9,28 +9,28 @@ function IndoorMapEntityInformationModuleImpl(emscriptenApi) {
     var _ready = false;
     var _notifyIndoorMapEntityInformationChangedCallback = null;
 
-    var _createPendingIndoorMapEntityInformations = function() {
-        _pendingIndoorEntityInformation.forEach(function(indoorMapEntityInformation) {
+    var _createPendingIndoorMapEntityInformations = () => {
+        _pendingIndoorEntityInformation.forEach(function (indoorMapEntityInformation) {
             _createAndAdd(indoorMapEntityInformation);
         });
 
         _pendingIndoorEntityInformation = [];
     };
 
-    var _createAndAdd = function(indoorMapEntityInformation) {
+    var _createAndAdd = (indoorMapEntityInformation) => {
         var nativeId = _emscriptenApi.indoorMapEntityInformationApi.createIndoorMapEntityInformation(indoorMapEntityInformation);
         _nativeIdToIndoorMapEntityInformation[nativeId] = indoorMapEntityInformation;
         indoorMapEntityInformation._setNativeHandle(nativeId);
 
-        if(nativeId in _callbackInvokedBeforeAssignement){
+        if (nativeId in _callbackInvokedBeforeAssignement) {
             delete _callbackInvokedBeforeAssignement[nativeId];
             _notifyIndoorMapEntityInformationChanged(nativeId);
         }
-        
+
         return nativeId;
     };
 
-    this.addIndoorMapEntityInformation = function(indoorMapEntityInformation) {
+    this.addIndoorMapEntityInformation = (indoorMapEntityInformation) => {
         if (_ready) {
             _createAndAdd(indoorMapEntityInformation);
         }
@@ -39,7 +39,7 @@ function IndoorMapEntityInformationModuleImpl(emscriptenApi) {
         }
     };
     
-    this.removeIndoorMapEntityInformation = function(indoorMapEntityInformation) {
+    this.removeIndoorMapEntityInformation = (indoorMapEntityInformation) => {
 
         if (!_ready) {
             var index = _pendingIndoorEntityInformation.indexOf(indoorMapEntityInformation);
@@ -59,26 +59,26 @@ function IndoorMapEntityInformationModuleImpl(emscriptenApi) {
         indoorMapEntityInformation._setNativeHandle(null);
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
         _emscriptenApi.indoorMapEntityInformationApi.registerIndoorMapEntityInformationChangedCallback(_executeIndoorMapEntityInformationChangedCallback);
         _createPendingIndoorMapEntityInformations();
     };
 
-    this.setIndoorMapEntityInformationChangedCallback = function(callback) {
+    this.setIndoorMapEntityInformationChangedCallback = (callback) => {
         _notifyIndoorMapEntityInformationChangedCallback = callback;
     };
 
-    var _executeIndoorMapEntityInformationChangedCallback = function(indoorMapEntityInformationId) {
+    var _executeIndoorMapEntityInformationChangedCallback = (indoorMapEntityInformationId) => {
         if (indoorMapEntityInformationId in _nativeIdToIndoorMapEntityInformation) {
             _notifyIndoorMapEntityInformationChanged(indoorMapEntityInformationId);
         }
-        else{
+        else {
             _callbackInvokedBeforeAssignement[indoorMapEntityInformationId] = true;
         }
     };
 
-    var _notifyIndoorMapEntityInformationChanged = function(indoorMapEntityInformationId) {
+    var _notifyIndoorMapEntityInformationChanged = (indoorMapEntityInformationId) => {
         var indoorMapEntityInformation = _nativeIdToIndoorMapEntityInformation[indoorMapEntityInformationId];
         var data = _emscriptenApi.indoorMapEntityInformationApi.tryGetIndoorMapEntityInformation(indoorMapEntityInformationId);
         if (data !== null) {
@@ -92,20 +92,17 @@ function IndoorMapEntityInformationModuleImpl(emscriptenApi) {
 
 function IndoorMapEntityInformationModule(emscriptenApi) {
     var _indoorMapEntityInformationModuleImpl = new IndoorMapEntityInformationModuleImpl(emscriptenApi);
-    var _this = this;
 
-    var _IndoorMapEntityInformationChangedHandler = function(indoorMapEntityInformation) {
-        _this.fire("indoormapentityinformationchanged", {indoorMapEntityInformation: indoorMapEntityInformation});
+    var _IndoorMapEntityInformationChangedHandler = (indoorMapEntityInformation) => {
+        this.fire("indoormapentityinformationchanged", { indoorMapEntityInformation: indoorMapEntityInformation });
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _indoorMapEntityInformationModuleImpl.setIndoorMapEntityInformationChangedCallback(_IndoorMapEntityInformationChangedHandler);
         _indoorMapEntityInformationModuleImpl.onInitialized();
     };
 
-    this._getImpl = function() {
-        return _indoorMapEntityInformationModuleImpl;
-    };
+    this._getImpl = () => _indoorMapEntityInformationModuleImpl;
 }
 
 var IndoorMapEntityInformationModulePrototype = L.extend({}, MapModule, L.Mixin.Events);

--- a/src/private/indoor_map_entity_information_module.js
+++ b/src/private/indoor_map_entity_information_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 function IndoorMapEntityInformationModuleImpl(emscriptenApi) {
 
@@ -112,4 +112,4 @@ var IndoorMapEntityInformationModulePrototype = L.extend({}, MapModule, L.Mixin.
 
 IndoorMapEntityInformationModule.prototype = IndoorMapEntityInformationModulePrototype;
 
-module.exports = IndoorMapEntityInformationModule;
+export default IndoorMapEntityInformationModule;

--- a/src/private/indoor_map_floor_outline_information_module.js
+++ b/src/private/indoor_map_floor_outline_information_module.js
@@ -1,7 +1,6 @@
 import MapModule from "./map_module";
 
-function IndoorMapFloorOutlineInformationModuleImpl(emscriptenApi) {
-
+export function IndoorMapFloorOutlineInformationModuleImpl(emscriptenApi) {
     var _emscriptenApi = emscriptenApi;
     var _nativeIdToIndoorMapFloorOutlineInformation = {};
     var _callbackInvokedBeforeAssignement = {};
@@ -9,20 +8,20 @@ function IndoorMapFloorOutlineInformationModuleImpl(emscriptenApi) {
     var _ready = false;
     var _notifyIndoorMapFloorOutlineInformationLoadedCallback = null;
 
-    var _createPendingIndoorMapFloorOutlineInformations = function() {
-        _pendingIndoorMapFloorOutlineInformation.forEach(function(indoorMapFloorOutlineInformation) {
+    var _createPendingIndoorMapFloorOutlineInformations = () => {
+        _pendingIndoorMapFloorOutlineInformation.forEach((indoorMapFloorOutlineInformation) => {
             _createAndAdd(indoorMapFloorOutlineInformation);
         });
 
         _pendingIndoorMapFloorOutlineInformation = [];
     };
 
-    var _createAndAdd = function(indoorMapFloorOutlineInformation) {
+    var _createAndAdd = (indoorMapFloorOutlineInformation) => {
         var nativeId = _emscriptenApi.indoorMapFloorOutlineInformationApi.createIndoorMapFloorOutlineInformation(indoorMapFloorOutlineInformation);
         _nativeIdToIndoorMapFloorOutlineInformation[nativeId] = indoorMapFloorOutlineInformation;
         indoorMapFloorOutlineInformation._setNativeHandle(nativeId);
 
-        if(nativeId in _callbackInvokedBeforeAssignement){
+        if (nativeId in _callbackInvokedBeforeAssignement) {
             delete _callbackInvokedBeforeAssignement[nativeId];
             _fetchIndoorMapFloorOutlineInformation(nativeId);
         }
@@ -30,7 +29,7 @@ function IndoorMapFloorOutlineInformationModuleImpl(emscriptenApi) {
         return nativeId;
     };
 
-    this.addIndoorMapFloorOutlineInformation = function(indoorMapFloorOutlineInformation) {
+    this.addIndoorMapFloorOutlineInformation = (indoorMapFloorOutlineInformation) => {
         if (_ready) {
             _createAndAdd(indoorMapFloorOutlineInformation);
         }
@@ -39,7 +38,7 @@ function IndoorMapFloorOutlineInformationModuleImpl(emscriptenApi) {
         }
     };
     
-    this.removeIndoorMapFloorOutlineInformation = function(indoorMapFloorOutlineInformation) {
+    this.removeIndoorMapFloorOutlineInformation = (indoorMapFloorOutlineInformation) => {
 
         if (!_ready) {
             var index = _pendingIndoorMapFloorOutlineInformation.indexOf(indoorMapFloorOutlineInformation);
@@ -59,26 +58,26 @@ function IndoorMapFloorOutlineInformationModuleImpl(emscriptenApi) {
         indoorMapFloorOutlineInformation._setNativeHandle(null);
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
         _emscriptenApi.indoorMapFloorOutlineInformationApi.registerIndoorMapFloorOutlineInformationLoadedCallback(_executeIndoorMapFloorOutlineInformationLoadedCallback);
         _createPendingIndoorMapFloorOutlineInformations();
     };
 
-    this.setIndoorMapFloorOutlineInformationLoadedCallback = function(callback) {
+    this.setIndoorMapFloorOutlineInformationLoadedCallback = (callback) => {
         _notifyIndoorMapFloorOutlineInformationLoadedCallback = callback;
     };
 
-    var _executeIndoorMapFloorOutlineInformationLoadedCallback = function(indoorMapFloorOutlineInformationId) {
+    var _executeIndoorMapFloorOutlineInformationLoadedCallback = (indoorMapFloorOutlineInformationId) => {
         if (indoorMapFloorOutlineInformationId in _nativeIdToIndoorMapFloorOutlineInformation) {
             _fetchIndoorMapFloorOutlineInformation(indoorMapFloorOutlineInformationId);
         }
-        else{
+        else {
             _callbackInvokedBeforeAssignement[indoorMapFloorOutlineInformationId] = true;
         }
     };
 
-    var _fetchIndoorMapFloorOutlineInformation = function(indoorMapFloorOutlineInformationId) {
+    var _fetchIndoorMapFloorOutlineInformation = (indoorMapFloorOutlineInformationId) => {
         var indoorMapFloorOutlineInformation = _nativeIdToIndoorMapFloorOutlineInformation[indoorMapFloorOutlineInformationId];
         if (_emscriptenApi.indoorMapFloorOutlineInformationApi.getIndoorMapFloorOutlineInformationLoaded(indoorMapFloorOutlineInformationId)) {
             var data = _emscriptenApi.indoorMapFloorOutlineInformationApi.tryGetIndoorMapFloorOutlineInformation(indoorMapFloorOutlineInformationId);
@@ -94,20 +93,18 @@ function IndoorMapFloorOutlineInformationModuleImpl(emscriptenApi) {
 
 function IndoorMapFloorOutlineInformationModule(emscriptenApi) {
     var _indoorMapFloorOutlineInformationModuleImpl = new IndoorMapFloorOutlineInformationModuleImpl(emscriptenApi);
-    var _this = this;
+    
 
-    var _IndoorMapFloorOutlineInformationLoadedHandler = function(indoorMapFloorOutlineInformation) {
-        _this.fire("indoormapflooroutlineinformationloaded", {indoorMapFloorOutlineInformation: indoorMapFloorOutlineInformation});
+    var _IndoorMapFloorOutlineInformationLoadedHandler = (indoorMapFloorOutlineInformation) => {
+        this.fire("indoormapflooroutlineinformationloaded", { indoorMapFloorOutlineInformation: indoorMapFloorOutlineInformation });
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _indoorMapFloorOutlineInformationModuleImpl.setIndoorMapFloorOutlineInformationLoadedCallback(_IndoorMapFloorOutlineInformationLoadedHandler);
         _indoorMapFloorOutlineInformationModuleImpl.onInitialized();
     };
 
-    this._getImpl = function() {
-        return _indoorMapFloorOutlineInformationModuleImpl;
-    };
+    this._getImpl = () => _indoorMapFloorOutlineInformationModuleImpl;
 }
 
 var IndoorMapFloorOutlineInformationModulePrototype = L.extend({}, MapModule, L.Mixin.Events);

--- a/src/private/indoor_map_floor_outline_information_module.js
+++ b/src/private/indoor_map_floor_outline_information_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 function IndoorMapFloorOutlineInformationModuleImpl(emscriptenApi) {
 
@@ -114,4 +114,4 @@ var IndoorMapFloorOutlineInformationModulePrototype = L.extend({}, MapModule, L.
 
 IndoorMapFloorOutlineInformationModule.prototype = IndoorMapFloorOutlineInformationModulePrototype;
 
-module.exports = IndoorMapFloorOutlineInformationModule;
+export default IndoorMapFloorOutlineInformationModule;

--- a/src/private/indoor_map_layer_options.js
+++ b/src/private/indoor_map_layer_options.js
@@ -1,6 +1,4 @@
-var exports = module.exports = {};
-
-var _getOptionsPropertyOrNull = function(layer, propertyName) {
+const _getOptionsPropertyOrNull = function(layer, propertyName) {
     if (typeof layer.options === "undefined") {
         return null;
     }
@@ -12,20 +10,20 @@ var _getOptionsPropertyOrNull = function(layer, propertyName) {
     return null;
 };
 
-exports.getIndoorMapId = function(layer) {
+export const getIndoorMapId = function(layer) {
     var indoorMapId = _getOptionsPropertyOrNull(layer, "indoorMapId");    
     return indoorMapId === "" ? null : indoorMapId;
 };
 
-exports.hasIndoorMap = function(layer) {
-    return this.getIndoorMapId(layer) !== null;
+export const hasIndoorMap = function(layer) {
+    return getIndoorMapId(layer) !== null;
 };
 
-exports.getIndoorMapFloorId = function(layer) {
+export const getIndoorMapFloorId = function(layer) {
     return _getOptionsPropertyOrNull(layer, "indoorMapFloorId");
 };
 
-exports.getIndoorMapFloorIndex = function(layer) {
+export const getIndoorMapFloorIndex = function(layer) {
     var indoorMapFloorIndex = _getOptionsPropertyOrNull(layer, "indoorMapFloorIndex");
 
     if (indoorMapFloorIndex !== null) {
@@ -36,33 +34,33 @@ exports.getIndoorMapFloorIndex = function(layer) {
     return _getOptionsPropertyOrNull(layer, "indoorFloorIndex");
 };
 
-exports.getLayerDisplayOption = function(layer) {
+export const getLayerDisplayOption = function(layer) {
     var displayOption = _getOptionsPropertyOrNull(layer, "displayOption") || "currentFloor";
     return displayOption;
 };
 
-exports.matchesCurrentFloor = function(activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer) {
-    if (activeIndoorMapFloorId === this.getIndoorMapFloorId(layer)) {
+export const matchesCurrentFloor = function(activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer) {
+    if (activeIndoorMapFloorId === getIndoorMapFloorId(layer)) {
         return true;
     }
     
-    return activeIndoorMapFloorIndex === this.getIndoorMapFloorIndex(layer);
+    return activeIndoorMapFloorIndex === getIndoorMapFloorIndex(layer);
 };
 
-exports.matchesIndoorMap = function(activeIndoorMapId, activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer) {  
-    var displayOption = this.getLayerDisplayOption(layer);
+export const matchesIndoorMap = function(activeIndoorMapId, activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer) {  
+    var displayOption = getLayerDisplayOption(layer);
     
     if (displayOption === "always") {
         return true;
     }
 
-    if (displayOption === "currentIndoorMap" && activeIndoorMapId === this.getIndoorMapId(layer)) {
+    if (displayOption === "currentIndoorMap" && activeIndoorMapId === getIndoorMapId(layer)) {
         return true;
     }        
 
     if (displayOption === "currentFloor" && 
-        activeIndoorMapId === this.getIndoorMapId(layer) &&
-        this.matchesCurrentFloor(activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer)
+        activeIndoorMapId === getIndoorMapId(layer) &&
+        matchesCurrentFloor(activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer)
     ) {
         return true;
     }
@@ -71,7 +69,7 @@ exports.matchesIndoorMap = function(activeIndoorMapId, activeIndoorMapFloorId, a
 
 };
 
-var _copyOption = function(sourceOptions, destOptions, sourcePropertyName, destPropertyName) {
+const _copyOption = function(sourceOptions, destOptions, sourcePropertyName, destPropertyName) {
     if (!(sourcePropertyName in sourceOptions)) {
         return;
     }
@@ -83,7 +81,7 @@ var _copyOption = function(sourceOptions, destOptions, sourcePropertyName, destP
     destOptions[destPropertyName] = sourceOptions[sourcePropertyName];
 };
 
-exports.copyIndoorMapOptions = function(sourceOptions, destOptions) {
+export const copyIndoorMapOptions = function(sourceOptions, destOptions) {
     _copyOption(sourceOptions, destOptions, "indoorMapId", "indoorMapId");
     _copyOption(sourceOptions, destOptions, "indoorMapFloorId", "indoorMapFloorId");
     _copyOption(sourceOptions, destOptions, "indoorMapFloorIndex", "indoorMapFloorIndex");

--- a/src/private/indoor_map_layer_options.js
+++ b/src/private/indoor_map_layer_options.js
@@ -1,4 +1,4 @@
-const _getOptionsPropertyOrNull = function(layer, propertyName) {
+const _getOptionsPropertyOrNull = (layer, propertyName) => {
     if (typeof layer.options === "undefined") {
         return null;
     }
@@ -10,20 +10,16 @@ const _getOptionsPropertyOrNull = function(layer, propertyName) {
     return null;
 };
 
-export const getIndoorMapId = function(layer) {
-    var indoorMapId = _getOptionsPropertyOrNull(layer, "indoorMapId");    
+export const getIndoorMapId = (layer) => {
+    var indoorMapId = _getOptionsPropertyOrNull(layer, "indoorMapId");
     return indoorMapId === "" ? null : indoorMapId;
 };
 
-export const hasIndoorMap = function(layer) {
-    return getIndoorMapId(layer) !== null;
-};
+export const hasIndoorMap = (layer) => getIndoorMapId(layer) !== null;
 
-export const getIndoorMapFloorId = function(layer) {
-    return _getOptionsPropertyOrNull(layer, "indoorMapFloorId");
-};
+export const getIndoorMapFloorId = (layer) => _getOptionsPropertyOrNull(layer, "indoorMapFloorId");
 
-export const getIndoorMapFloorIndex = function(layer) {
+export const getIndoorMapFloorIndex = (layer) => {
     var indoorMapFloorIndex = _getOptionsPropertyOrNull(layer, "indoorMapFloorIndex");
 
     if (indoorMapFloorIndex !== null) {
@@ -34,34 +30,33 @@ export const getIndoorMapFloorIndex = function(layer) {
     return _getOptionsPropertyOrNull(layer, "indoorFloorIndex");
 };
 
-export const getLayerDisplayOption = function(layer) {
+export const getLayerDisplayOption = (layer) => {
     var displayOption = _getOptionsPropertyOrNull(layer, "displayOption") || "currentFloor";
     return displayOption;
 };
 
-export const matchesCurrentFloor = function(activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer) {
+export const matchesCurrentFloor = (activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer) => {
     if (activeIndoorMapFloorId === getIndoorMapFloorId(layer)) {
         return true;
     }
-    
+
     return activeIndoorMapFloorIndex === getIndoorMapFloorIndex(layer);
 };
 
-export const matchesIndoorMap = function(activeIndoorMapId, activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer) {  
+export const matchesIndoorMap = (activeIndoorMapId, activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer) => {
     var displayOption = getLayerDisplayOption(layer);
-    
+
     if (displayOption === "always") {
         return true;
     }
 
     if (displayOption === "currentIndoorMap" && activeIndoorMapId === getIndoorMapId(layer)) {
         return true;
-    }        
+    }
 
-    if (displayOption === "currentFloor" && 
+    if (displayOption === "currentFloor" &&
         activeIndoorMapId === getIndoorMapId(layer) &&
-        matchesCurrentFloor(activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer)
-    ) {
+        matchesCurrentFloor(activeIndoorMapFloorId, activeIndoorMapFloorIndex, layer)) {
         return true;
     }
 
@@ -69,19 +64,19 @@ export const matchesIndoorMap = function(activeIndoorMapId, activeIndoorMapFloor
 
 };
 
-const _copyOption = function(sourceOptions, destOptions, sourcePropertyName, destPropertyName) {
+const _copyOption = (sourceOptions, destOptions, sourcePropertyName, destPropertyName) => {
     if (!(sourcePropertyName in sourceOptions)) {
         return;
     }
 
     if (destPropertyName in destOptions) {
         return;
-    }    
-    
+    }
+
     destOptions[destPropertyName] = sourceOptions[sourcePropertyName];
 };
 
-export const copyIndoorMapOptions = function(sourceOptions, destOptions) {
+export const copyIndoorMapOptions = (sourceOptions, destOptions) => {
     _copyOption(sourceOptions, destOptions, "indoorMapId", "indoorMapId");
     _copyOption(sourceOptions, destOptions, "indoorMapFloorId", "indoorMapFloorId");
     _copyOption(sourceOptions, destOptions, "indoorMapFloorIndex", "indoorMapFloorIndex");

--- a/src/private/indoor_watermark_controller.js
+++ b/src/private/indoor_watermark_controller.js
@@ -1,4 +1,4 @@
-const IndoorWatermarkController = function(mapId, showWrldWatermark) {
+export function IndoorWatermarkController (mapId, showWrldWatermark) {
   var _indoorWatermarkElement = null;
   var _elementId = "wrld-indoor-map-watermark" + mapId;
   var _urlRoot = "https://cdn-webgl.wrld3d.com/wrldjs/resources/indoor-vendors/";
@@ -6,19 +6,18 @@ const IndoorWatermarkController = function(mapId, showWrldWatermark) {
 
   var _eegeoVenderKey = "eegeo";
 
-  var _buildUrlForVendor = function(vendorKey) {
+  var _buildUrlForVendor = (vendorKey) => {
     var vendorKeyLower = vendorKey.toLowerCase();
-    if (vendorKeyLower === _eegeoVenderKey)
-    {
-        vendorKeyLower = "wrld";
+    if (vendorKeyLower === _eegeoVenderKey) {
+      vendorKeyLower = "wrld";
     }
     return _urlRoot + vendorKeyLower + "_logo.png";
   };
 
-  var _precacheKnownVendors = function() {
+  var _precacheKnownVendors = () => {
     var knownVendors = [_eegeoVenderKey, "micello"];
 
-    knownVendors.forEach(function(vendor) {
+    knownVendors.forEach(function (vendor) {
       var vendorImageUrl = _buildUrlForVendor(vendor);
       var tempImage = new Image();
       tempImage.src = vendorImageUrl;
@@ -27,11 +26,10 @@ const IndoorWatermarkController = function(mapId, showWrldWatermark) {
 
   _precacheKnownVendors();
 
-  this.showWatermarkForVendor = function(vendorKey) {
+  this.showWatermarkForVendor = (vendorKey) => {
 
-    if((vendorKey === _eegeoVenderKey) && 
-        !_showWrldWatermark)
-    {
+    if ((vendorKey === _eegeoVenderKey) &&
+      !_showWrldWatermark) {
       return;
     }
 
@@ -45,12 +43,11 @@ const IndoorWatermarkController = function(mapId, showWrldWatermark) {
     _indoorWatermarkElement.style.bottom = 0;
   };
 
-  this.hideWatermark = function() {
-    if(_indoorWatermarkElement !== null)
-    {
+  this.hideWatermark = () => {
+    if (_indoorWatermarkElement !== null) {
       _indoorWatermarkElement.style.bottom = "-50px";
     }
   };
-};
+}
 
 export default IndoorWatermarkController;

--- a/src/private/indoor_watermark_controller.js
+++ b/src/private/indoor_watermark_controller.js
@@ -1,4 +1,4 @@
-var IndoorWatermarkController = function(mapId, showWrldWatermark) {
+const IndoorWatermarkController = function(mapId, showWrldWatermark) {
   var _indoorWatermarkElement = null;
   var _elementId = "wrld-indoor-map-watermark" + mapId;
   var _urlRoot = "https://cdn-webgl.wrld3d.com/wrldjs/resources/indoor-vendors/";
@@ -53,4 +53,4 @@ var IndoorWatermarkController = function(mapId, showWrldWatermark) {
   };
 };
 
-module.exports = IndoorWatermarkController;
+export default IndoorWatermarkController;

--- a/src/private/indoors_module.js
+++ b/src/private/indoors_module.js
@@ -2,7 +2,7 @@ import MapModule from "./map_module";
 import { IndoorMap, IndoorMapFloor, IndoorMapEntrance } from "../public/indoors/indoors";
 import IndoorWatermarkController from "./indoor_watermark_controller";
 
-var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floorIndex, center, headingDegrees, zoom, showWrldWatermark, backgroundColor) {
+function IndoorsModule (emscriptenApi, mapController, mapId, indoorId, floorIndex, center, headingDegrees, zoom, showWrldWatermark, backgroundColor) {
 
     var _emscriptenApi = emscriptenApi;
     var _mapController = mapController;
@@ -23,21 +23,21 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
     var _zoom = zoom;
     var _backgroundColor = backgroundColor;
 
-    var _this = this;
+    
 
-    var _createIndoorMapObject = function() {
+    var _createIndoorMapObject = () => {
         var mapId = _emscriptenApi.indoorsApi.getActiveIndoorMapId();
         var mapName = _emscriptenApi.indoorsApi.getActiveIndoorMapName();
         var sourceVendor = _emscriptenApi.indoorsApi.getActiveIndoorMapSourceVendor();
         var floorCount = _emscriptenApi.indoorsApi.getActiveIndoorMapFloorCount();
         var floors = _createFloorsArray(floorCount);
         var searchTags = _createSearchTagsArray();
-        var exitFunc = _this.exit;
+        var exitFunc = this.exit;
         var indoorMap = new IndoorMap(mapId, mapName, sourceVendor, floorCount, floors, searchTags, exitFunc);
         return indoorMap;
     };
 
-    var _createFloorsArray = function(floorCount) {
+    var _createFloorsArray = (floorCount) => {
         var floors = [];
         for (var i = 0; i < floorCount; ++i) {
             var floorIndex = i;
@@ -53,7 +53,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return floors;
     };
 
-    var _createSearchTagsArray = function() {
+    var _createSearchTagsArray = () => {
         var userData;
         try {
             userData = JSON.parse(_emscriptenApi.indoorsApi.getActiveIndoorMapUserData());
@@ -66,93 +66,93 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         if (!(userData.search_menu_items.items instanceof Array)) { return []; }
 
         var searchTags = [];
-        userData.search_menu_items.items.forEach(function(item) {
-            searchTags.push({
-                name: item.name,
-                search_tag: item.search_tag,
-                icon_key: item.icon_key
+        userData.search_menu_items.items.forEach((item) => {
+                searchTags.push({
+                    name: item.name,
+                    search_tag: item.search_tag,
+                    icon_key: item.icon_key
+                });
             });
-        });
         return searchTags;
     };
 
-    var _executeIndoorMapEnteredCallbacks = function() {
+    var _executeIndoorMapEnteredCallbacks = () => {
         _activeIndoorMap = _createIndoorMapObject();
-        _this.fire("indoormapenter", { indoorMap: _activeIndoorMap });
+        this.fire("indoormapenter", { indoorMap: _activeIndoorMap });
     };
 
-    var _executeIndoorMapEnterFailedCallbacks = function() {
-        _this.fire("indoormapenterfailed", {});
+    var _executeIndoorMapEnterFailedCallbacks = () => {
+        this.fire("indoormapenterfailed", {});
     };
 
-    var _executeIndoorMapExitedCallbacks = function() {
+    var _executeIndoorMapExitedCallbacks = () => {
         var indoorMap = _activeIndoorMap;
         _activeIndoorMap = null;
         _indoorWatermarkController.hideWatermark();
-        _this.fire("indoormapexit", { indoorMap: indoorMap });
+        this.fire("indoormapexit", { indoorMap: indoorMap });
     };
 
-    var _executeIndoorMapFloorChangedCallbacks = function() {
-        _this.fire("indoormapfloorchange", { floor: _this.getFloor() });
+    var _executeIndoorMapFloorChangedCallbacks = () => {
+        this.fire("indoormapfloorchange", { floor: this.getFloor() });
     };
 
-    var _executeIndoorMapEntranceAddedCallbacks = function(indoorMapId, indoorMapName, indoorMapLatLng) {
+    var _executeIndoorMapEntranceAddedCallbacks = (indoorMapId, indoorMapName, indoorMapLatLng) => {
         // discard the altitude, as we're going to use the SDK IPointOnMap positioning to snap it to the terrain (this is now default)
         // alternative is to use the altitude, but use "elevationMode: heightAboveSeaLevel" when creating the indoor entrance marker
         var entrance = new IndoorMapEntrance(indoorMapId, indoorMapName, L.latLng([indoorMapLatLng.lat, indoorMapLatLng.lng]));
         _entrances[entrance.getIndoorMapId()] = entrance;
-        _this.fire("indoorentranceadd", { entrance: entrance });
+        this.fire("indoorentranceadd", { entrance: entrance });
     };
 
-    var _executeIndoorMapEntranceRemovedCallbacks = function(indoorMapId, indoorMapName, indoorMapLatLng) {
+    var _executeIndoorMapEntranceRemovedCallbacks = (indoorMapId, indoorMapName, indoorMapLatLng) => {
         var entrance = new IndoorMapEntrance(indoorMapId, indoorMapName, indoorMapLatLng);
         delete _entrances[entrance.getIndoorMapId()];
-        _this.fire("indoorentranceremove", { entrance: entrance });
+        this.fire("indoorentranceremove", { entrance: entrance });
     };
 
-    var _executeIndoorMapLoadedCallbacks = function(indoorMapId) {
-        _this.fire("indoormapload", { indoorMapId: indoorMapId });
+    var _executeIndoorMapLoadedCallbacks = (indoorMapId) => {
+        this.fire("indoormapload", { indoorMapId: indoorMapId });
     };
 
-    var _executeIndoorMapUnloadedCallbacks = function(indoorMapId) {
-        _this.fire("indoormapunload", { indoorMapId: indoorMapId });
+    var _executeIndoorMapUnloadedCallbacks = (indoorMapId) => {
+        this.fire("indoormapunload", { indoorMapId: indoorMapId });
     };
 
-    var _executeEntityClickedCallbacks = function(ids) {
+    var _executeEntityClickedCallbacks = (ids) => {
         var idArray = ids.split("|");
-        _this.fire("indoorentityclick", { ids: idArray });
+        this.fire("indoorentityclick", { ids: idArray });
     };
 
-    var _onCollapseStart = function() {
-        _this.fire("collapsestart");
+    var _onCollapseStart = () => {
+        this.fire("collapsestart");
     };
 
-    var _onCollapse = function() {
-        _this.fire("collapse");
+    var _onCollapse = () => {
+        this.fire("collapse");
     };
 
-    var _onCollapseEnd = function() {
-        _this.fire("collapseend");
+    var _onCollapseEnd = () => {
+        this.fire("collapseend");
     };
 
-    var _onExpandStart = function() {
-        _this.fire("expandstart");
+    var _onExpandStart = () => {
+        this.fire("expandstart");
     };
 
-    var _onExpand = function() {
-        _this.fire("expand");
+    var _onExpand = () => {
+        this.fire("expand");
     };
 
-    var _onExpandEnd = function() {
-        _this.fire("expandend");
+    var _onExpandEnd = () => {
+        this.fire("expandend");
     };
 
-    var _enterIndoorMap = function(indoorMapId) {
-        _this.fire("indoormapenterrequested");
+    var _enterIndoorMap = (indoorMapId) => {
+        this.fire("indoormapenterrequested");
         _emscriptenApi.indoorsApi.enterIndoorMap(indoorMapId);
     };
 
-    var _transitionToIndoorMap = function(config) {
+    var _transitionToIndoorMap = (config) => {
 
         _transitioningToIndoorMap = true;
 
@@ -162,19 +162,19 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         }
         var animated = "animate" in config ? config["animate"] : true;
         _emscriptenApi.cameraApi.setView({ location: config.latLng, distance: config.distance, allowInterruption: false, headingDegrees: config.orientation, animate: animated });
-        _mapController._setIndoorTransitionCompleteEventListener(function() { _enterIndoorMap(config.indoorMapId); });
+        _mapController._setIndoorTransitionCompleteEventListener(function () { _enterIndoorMap(config.indoorMapId); });
 
-        _this.once("indoormapenter", function() {
-            _transitioningToIndoorMap = false;
-            var vendorKey = _activeIndoorMap.getIndoorMapSourceVendor();
-            _indoorWatermarkController.showWatermarkForVendor(vendorKey);
-        });
-        _this.once("indoormapenterfailed", function() {
-            _transitioningToIndoorMap = false;
-        });
+        this.once("indoormapenter", () => {
+                _transitioningToIndoorMap = false;
+                var vendorKey = _activeIndoorMap.getIndoorMapSourceVendor();
+                _indoorWatermarkController.showWatermarkForVendor(vendorKey);
+            });
+        this.once("indoormapenterfailed", () => {
+                _transitioningToIndoorMap = false;
+            });
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _emscriptenApi.indoorsApi.onInitialized();
 
         _emscriptenApi.indoorsApi.setNotificationCallbacks(
@@ -202,7 +202,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         _emscriptenApi.indoorsApi.setBackgroundColor(_backgroundColor);
     };
 
-    this.onInitialStreamingCompleted = function() {
+    this.onInitialStreamingCompleted = () => {
         _ready = true;
 
         if (_startingIndoorId) {
@@ -225,7 +225,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         }
     };
 
-    this.exit = function() {
+    this.exit = () => {
         if (_emscriptenApi.ready()) {
             _emscriptenApi.indoorsApi.exitIndoorMap();
             _indoorWatermarkController.hideWatermark();
@@ -235,15 +235,11 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return this;
     };
 
-    this.isIndoors = function() {
-        return _activeIndoorMap !== null;
-    };
+    this.isIndoors = () => _activeIndoorMap !== null;
 
-    this.getActiveIndoorMap = function() {
-        return _activeIndoorMap;
-    };
+    this.getActiveIndoorMap = () => _activeIndoorMap;
 
-    this.getFloor = function() {
+    this.getFloor = () => {
         if (this.isIndoors()) {
             var index = _emscriptenApi.indoorsApi.getSelectedFloorIndex();
             return _activeIndoorMap.getFloors()[index];
@@ -251,7 +247,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return null;
     };
 
-    this.setFloor = function(floor) {
+    this.setFloor = (floor) => {
         if (!this.isIndoors()) {
             return false;
         }
@@ -282,7 +278,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return false;
     };
 
-    this.moveUp = function(numberOfFloors) {
+    this.moveUp = (numberOfFloors) => {
         var delta = (typeof numberOfFloors === "undefined") ? 1 : numberOfFloors;
         var thisFloor = this.getFloor();
         if (thisFloor === null) {
@@ -291,12 +287,12 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return this.setFloor(thisFloor.getFloorIndex() + delta);
     };
 
-    this.moveDown = function(numberOfFloors) {
+    this.moveDown = (numberOfFloors) => {
         var delta = (typeof numberOfFloors === "undefined") ? -1 : -numberOfFloors;
         return this.moveUp(delta);
     };
 
-    this.enter = function(indoorMap, config) {
+    this.enter = (indoorMap, config) => {
         if (this.isIndoors() || _transitioningToIndoorMap) {
             return false;
         }
@@ -342,7 +338,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return true;
     };
 
-    this.getFloorInterpolation = function() {
+    this.getFloorInterpolation = () => {
         if (_activeIndoorMap !== null) {
             var floorParam = _emscriptenApi.expandFloorsApi.getFloorParam();
             var normalizedValue = floorParam / _activeIndoorMap.getFloorCount();
@@ -351,7 +347,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return 0;
     };
 
-    this.getFloorHeightAboveSeaLevel = function(floorIndex) {
+    this.getFloorHeightAboveSeaLevel = (floorIndex) => {
         if (this.isIndoors() &&
             floorIndex >= 0 &&
             floorIndex < _activeIndoorMap.getFloorCount()) {
@@ -361,28 +357,28 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return null;
     };
 
-    this.tryGetReadableName = function(indoorMapId) {
+    this.tryGetReadableName = (indoorMapId) => {
         if (_emscriptenApi.ready()) {
             return _emscriptenApi.indoorsApi.tryGetReadableName(indoorMapId);
         }
         return null;
     };
 
-    this.tryGetFloorReadableName = function(indoorMapId, indoorMapFloorId) {
+    this.tryGetFloorReadableName = (indoorMapId, indoorMapFloorId) => {
         if (_emscriptenApi.ready()) {
             return _emscriptenApi.indoorsApi.tryGetFloorReadableName(indoorMapId, indoorMapFloorId);
         }
         return null;
     };
 
-    this.tryGetFloorShortName = function(indoorMapId, indoorMapFloorId) {
+    this.tryGetFloorShortName = (indoorMapId, indoorMapFloorId) => {
         if (_emscriptenApi.ready()) {
             return _emscriptenApi.indoorsApi.tryGetFloorShortName(indoorMapId, indoorMapFloorId);
         }
         return null;
     };
 
-    this.setFloorInterpolation = function(value) {
+    this.setFloorInterpolation = (value) => {
         if (_activeIndoorMap !== null) {
             var floorParam = value * _activeIndoorMap.getFloorCount();
             _emscriptenApi.expandFloorsApi.setFloorParam(floorParam);
@@ -390,7 +386,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return this;
     };
 
-    this.setFloorFromInterpolation = function(interpolationParam) {
+    this.setFloorFromInterpolation = (interpolationParam) => {
         if (_activeIndoorMap === null) {
             return false;
         }
@@ -400,17 +396,17 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return this.setFloor(floorIndex);
     };
 
-    this.expand = function() {
+    this.expand = () => {
         _emscriptenApi.expandFloorsApi.expandIndoorMap();
         return this;
     };
 
-    this.collapse = function() {
+    this.collapse = () => {
         _emscriptenApi.expandFloorsApi.collapseIndoorMap();
         return this;
     };
 
-    this.setEntityHighlights = function(ids, highlightColor, indoorMapId, highlightBorderThickness) {
+    this.setEntityHighlights = (ids, highlightColor, indoorMapId, highlightBorderThickness) => {
         if (!_ready) return;
 
         indoorMapId = _indoorMapIdOrDefault(indoorMapId);
@@ -418,14 +414,14 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         _emscriptenApi.indoorEntityApi.setHighlights(ids, highlightColor, indoorMapId, highlightBorderThickness);
     };
 
-    this.clearEntityHighlights = function(ids, indoorMapId) {
+    this.clearEntityHighlights = (ids, indoorMapId) => {
         if (!_ready) return;
 
         indoorMapId = _indoorMapIdOrDefault(indoorMapId);
         _emscriptenApi.indoorEntityApi.clearHighlights(ids, indoorMapId);
     };
 
-    var _borderThicknessOrDefault = function(borderThickness) {
+    var _borderThicknessOrDefault = (borderThickness) => {
         if (borderThickness === undefined || borderThickness === null) {
             borderThickness = 0.5;
         }
@@ -433,7 +429,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return borderThickness;
     };
 
-    var _indoorMapIdOrDefault = function(indoorMapId) {
+    var _indoorMapIdOrDefault = (indoorMapId) => {
         if (indoorMapId === undefined || indoorMapId === null) {
             if (_activeIndoorMap !== null) {
                 indoorMapId = _activeIndoorMap.getIndoorMapId();
@@ -443,18 +439,18 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return indoorMapId;
     };
 
-    this.setBackgroundColor = function(color) {
+    this.setBackgroundColor = (color) => {
         _backgroundColor = color;
         if (!_ready) return;
 
         _emscriptenApi.indoorsApi.setBackgroundColor(color);
     };
 
-    this.hideLabelsForEntity = function(entityName) {
+    this.hideLabelsForEntity = (entityName) => {
         return this.hideLabelsForEntities([entityName]);
     };
 
-    this.hideLabelsForEntities = function(entityNames) {
+    this.hideLabelsForEntities = (entityNames) => {
         if (_emscriptenApi.ready()) {
             _emscriptenApi.indoorsApi.hideLabelsForEntities(entityNames);
         }
@@ -462,11 +458,11 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return this;
     };
     
-    this.showLabelsForEntity = function(entityName) {
+    this.showLabelsForEntity = (entityName) => {
         return this.showLabelsForEntities([entityName]);
     };
 
-    this.showLabelsForEntities = function(entityNames) {
+    this.showLabelsForEntities = (entityNames) => {
         if (_emscriptenApi.ready()) {
             _emscriptenApi.indoorsApi.showLabelsForEntities(entityNames);
         }
@@ -474,7 +470,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return this;
     };
 
-    this.showAllLabels = function() {
+    this.showAllLabels = () => {
         if (_emscriptenApi.ready()) {
             _emscriptenApi.indoorsApi.showAllLabels();
         }
@@ -482,7 +478,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         return this;
     };
 
-};
+}
 
 var IndoorsPrototype = L.extend({}, MapModule, L.Mixin.Events);
 

--- a/src/private/indoors_module.js
+++ b/src/private/indoors_module.js
@@ -1,6 +1,6 @@
-var MapModule = require("./map_module");
-var indoors = require("../public/indoors/indoors");
-var IndoorWatermarkController = require("./indoor_watermark_controller");
+import MapModule from "./map_module";
+import { IndoorMap, IndoorMapFloor, IndoorMapEntrance } from "../public/indoors/indoors";
+import IndoorWatermarkController from "./indoor_watermark_controller";
 
 var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floorIndex, center, headingDegrees, zoom, showWrldWatermark, backgroundColor) {
 
@@ -33,7 +33,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
         var floors = _createFloorsArray(floorCount);
         var searchTags = _createSearchTagsArray();
         var exitFunc = _this.exit;
-        var indoorMap = new indoors.IndoorMap(mapId, mapName, sourceVendor, floorCount, floors, searchTags, exitFunc);
+        var indoorMap = new IndoorMap(mapId, mapName, sourceVendor, floorCount, floors, searchTags, exitFunc);
         return indoorMap;
     };
 
@@ -47,7 +47,7 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
 
             var floorId = floorNumber;
 
-            var floor = new indoors.IndoorMapFloor(floorId, floorIndex, floorName, floorShortName);
+            var floor = new IndoorMapFloor(floorId, floorIndex, floorName, floorShortName);
             floors.push(floor);
         }
         return floors;
@@ -99,13 +99,13 @@ var IndoorsModule = function(emscriptenApi, mapController, mapId, indoorId, floo
     var _executeIndoorMapEntranceAddedCallbacks = function(indoorMapId, indoorMapName, indoorMapLatLng) {
         // discard the altitude, as we're going to use the SDK IPointOnMap positioning to snap it to the terrain (this is now default)
         // alternative is to use the altitude, but use "elevationMode: heightAboveSeaLevel" when creating the indoor entrance marker
-        var entrance = new indoors.IndoorMapEntrance(indoorMapId, indoorMapName, L.latLng([indoorMapLatLng.lat, indoorMapLatLng.lng]));
+        var entrance = new IndoorMapEntrance(indoorMapId, indoorMapName, L.latLng([indoorMapLatLng.lat, indoorMapLatLng.lng]));
         _entrances[entrance.getIndoorMapId()] = entrance;
         _this.fire("indoorentranceadd", { entrance: entrance });
     };
 
     var _executeIndoorMapEntranceRemovedCallbacks = function(indoorMapId, indoorMapName, indoorMapLatLng) {
-        var entrance = new indoors.IndoorMapEntrance(indoorMapId, indoorMapName, indoorMapLatLng);
+        var entrance = new IndoorMapEntrance(indoorMapId, indoorMapName, indoorMapLatLng);
         delete _entrances[entrance.getIndoorMapId()];
         _this.fire("indoorentranceremove", { entrance: entrance });
     };
@@ -488,4 +488,4 @@ var IndoorsPrototype = L.extend({}, MapModule, L.Mixin.Events);
 
 IndoorsModule.prototype = IndoorsPrototype;
 
-module.exports = IndoorsModule;
+export default IndoorsModule;

--- a/src/private/layer_point_mapping_module.js
+++ b/src/private/layer_point_mapping_module.js
@@ -4,39 +4,34 @@ import { getElevationModeInt } from "./elevation_mode.js";
 
 var _undefinedPoint = L.point(-100, -100);
 
-var LayerPointMappingModule = function(emscriptenApi) {
+function LayerPointMappingModule (emscriptenApi) {
     var _emscriptenApi = emscriptenApi;
     var _spacesApi = null;
     var _ready = false;
     var _layerToLatLngsMapping = {};
-    var _this = this;  
     var _pendingMappings = [];
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
         _spacesApi = _emscriptenApi.spacesApi;
         this._createPendingLayers();
     };       
 
     // https://stackoverflow.com/a/15030117
-    var _flatten = function(arr) {
-        return arr.reduce(function (flat, toFlatten) {
-            return flat.concat(Array.isArray(toFlatten) ? _flatten(toFlatten) : toFlatten);
-        }, []);
-    };
+    var _flatten = (arr) => arr.reduce(function (flat, toFlatten) {
+        return flat.concat(Array.isArray(toFlatten) ? _flatten(toFlatten) : toFlatten);
+    }, []);
 
-    this._getLayerId = function(layer) {
-        return L.stamp(layer);
-    };
+    this._getLayerId = (layer) => L.stamp(layer);
 
-    this._useWrldSdkPointMappingForLayer = function(layer) {        
+    this._useWrldSdkPointMappingForLayer = (layer) => {
         if (typeof layer.getLatLng !== "function" && typeof layer.getLatLngs !== "function") {
             return false;
         }
         return true;
     };
 
-    this._createAndAdd = function(layer) {
+    this._createAndAdd = (layer) => {
         if (!this._useWrldSdkPointMappingForLayer(layer)) {
             return;
         }
@@ -79,14 +74,14 @@ var LayerPointMappingModule = function(emscriptenApi) {
         _layerToLatLngsMapping[id] = api.getLatLngsForLayer(id, latLngsFlatArray.length);
     };
 
-    this._createPendingLayers = function() {
-        _pendingMappings.forEach(function(layer) {
-            _this._createAndAdd(layer);
-        });
-        _pendingMappings = [];            
+    this._createPendingLayers = () => {
+        _pendingMappings.forEach((layer) => {
+                this._createAndAdd(layer);
+            });
+        _pendingMappings = [];
     };
 
-    this.createPointMapping = function(layer) {        
+    this.createPointMapping = (layer) => {
         if (!this._useWrldSdkPointMappingForLayer(layer)) {
             return;
         }
@@ -99,7 +94,7 @@ var LayerPointMappingModule = function(emscriptenApi) {
         this._createAndAdd(layer);
     };
 
-    this.removePointMapping = function(layer) {        
+    this.removePointMapping = (layer) => {
         if(!_ready) {
             var index = _pendingMappings.indexOf(layer);
             if (index > -1) {
@@ -120,21 +115,21 @@ var LayerPointMappingModule = function(emscriptenApi) {
         }
     };
 
-    this._updateMappings = function() {
+    this._updateMappings = () => {
         if (!_ready) {
             return;
         }
 
         var api = _emscriptenApi.layerPointMappingApi;
 
-        for (var id in _layerToLatLngsMapping) {            
+        for (var id in _layerToLatLngsMapping) {
             var latLngCount = _layerToLatLngsMapping[id].length;
-            
+
             _layerToLatLngsMapping[id] = api.getLatLngsForLayer(id, latLngCount);
         }
     };
 
-    this.onDraw = function() {
+    this.onDraw = () => {
         if (!_ready) {
             return;
         }
@@ -142,19 +137,19 @@ var LayerPointMappingModule = function(emscriptenApi) {
         this._updateMappings();
     };
 
-    this._getDefaultLatLngsFromLayer = function(layer) {
+    this._getDefaultLatLngsFromLayer = (layer) => {
         if (typeof layer.getLatLngs === "function") {
             return layer.getLatLngs();
         }
 
         if (typeof layer.getLatLng === "function") {
-            return [ layer.getLatLng() ];
+            return [layer.getLatLng()];
         }
 
         return null;
     };
 
-    this.latLngsForLayer = function(layer) {        
+    this.latLngsForLayer = (layer) => {        
         if(!_ready) {            
             return this._getDefaultLatLngsFromLayer(layer);
         }
@@ -171,7 +166,7 @@ var LayerPointMappingModule = function(emscriptenApi) {
         return this._getDefaultLatLngsFromLayer(layer);
     };
 
-    this.projectLatlngs = function(layer, latlngs, result, projectedBounds) {
+    this.projectLatlngs = (layer, latlngs, result, projectedBounds) => {
         if(!_ready) {
             return false;
         }
@@ -194,11 +189,11 @@ var LayerPointMappingModule = function(emscriptenApi) {
         return true;
     };
 
-    this._latLngToLayerPoint = function(latlng) {
+    this._latLngToLayerPoint = (latlng) => {
         return (_ready) ? _spacesApi.worldToScreen(latlng).toPoint() : _undefinedPoint;
     };
 
-    this._projectLatlngsRecursive = function(originalLatlngs, associatedFlatLatlngArray, currentFlatIndex, result, projectedBounds) {       
+    this._projectLatlngsRecursive = (originalLatlngs, associatedFlatLatlngArray, currentFlatIndex, result, projectedBounds) => {
         var flat = originalLatlngs[0] instanceof L.LatLng,
             len = originalLatlngs.length,
             i, ring;
@@ -225,7 +220,7 @@ var LayerPointMappingModule = function(emscriptenApi) {
 
         return currentFlatIndex;
     };
-};
+}
 
 LayerPointMappingModule.prototype = MapModule;
 

--- a/src/private/layer_point_mapping_module.js
+++ b/src/private/layer_point_mapping_module.js
@@ -1,6 +1,6 @@
-var MapModule = require("./map_module");
-var indoorOptions = require("./indoor_map_layer_options.js");
-var elevationMode = require("./elevation_mode.js");
+import MapModule from "./map_module";
+import { getIndoorMapId, getIndoorMapFloorIndex, getIndoorMapFloorId } from "./indoor_map_layer_options.js";
+import { getElevationModeInt } from "./elevation_mode.js";
 
 var _undefinedPoint = L.point(-100, -100);
 
@@ -52,21 +52,21 @@ var LayerPointMappingModule = function(emscriptenApi) {
 
         var elevation = layer.options.elevation || 0.0;
         
-        var elevationModeInt = elevationMode.getElevationModeInt(layer.options.elevationMode);
+        var elevationModeInt = getElevationModeInt(layer.options.elevationMode);
 
         var api = _emscriptenApi.layerPointMappingApi;
         
         // due to legacy uses where positions were defined using floor index (poi tool, for example)
         // check to see if we're dealing with a floor index, and use that instead. Floor id & index 
         // have different semantics, so they cannot be used interchangeably.
-        var indoorMapId = indoorOptions.getIndoorMapId(layer);
-        var indoorMapFloorIndex = indoorOptions.getIndoorMapFloorIndex(layer);
+        var indoorMapId = getIndoorMapId(layer);
+        var indoorMapFloorIndex = getIndoorMapFloorIndex(layer);
         var indoorMapWithFloorIndex = indoorMapId !== null && indoorMapFloorIndex !== null;
 
         if(indoorMapWithFloorIndex === true) {
             api.createPointMappingWithFloorIndex(id, elevation, elevationModeInt, indoorMapId, indoorMapFloorIndex, latLngsFlatArray);
         } else {
-            var indoorMapFloorId = indoorOptions.getIndoorMapFloorId(layer);
+            var indoorMapFloorId = getIndoorMapFloorId(layer);
             var indoorOptionsValid = indoorMapId !== null && indoorMapFloorId !== null;            
 
             // in the case where _either_ the indoor map id or the floor id is invalid, use neither (defaults to outside)
@@ -228,4 +228,5 @@ var LayerPointMappingModule = function(emscriptenApi) {
 };
 
 LayerPointMappingModule.prototype = MapModule;
-module.exports = LayerPointMappingModule;
+
+export default LayerPointMappingModule;

--- a/src/private/map_module.js
+++ b/src/private/map_module.js
@@ -1,18 +1,14 @@
 export const MapModule = {
-    onUpdate: function(dt) {
-
+    onUpdate: (dt) => {
     },
 
-    onDraw: function(dt) {
-
+    onDraw: (dt) => {
     },
 
-    onInitialized: function() {
-
+    onInitialized: () => {
     },
 
-    onInitialStreamingCompleted: function() {
-        
+    onInitialStreamingCompleted: () => {
     }
 };
 

--- a/src/private/map_module.js
+++ b/src/private/map_module.js
@@ -1,4 +1,4 @@
-var MapModule = {
+export const MapModule = {
     onUpdate: function(dt) {
 
     },
@@ -16,4 +16,4 @@ var MapModule = {
     }
 };
 
-module.exports = MapModule;
+export default MapModule;

--- a/src/private/map_runtime_module.js
+++ b/src/private/map_runtime_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 function MapRuntimeModule(emscriptenApi) {
 
@@ -27,6 +27,7 @@ function MapRuntimeModule(emscriptenApi) {
         _ready = true;
     };
 }
+
 MapRuntimeModule.prototype = MapModule;
 
-module.exports = MapRuntimeModule;
+export default MapRuntimeModule;

--- a/src/private/map_runtime_module.js
+++ b/src/private/map_runtime_module.js
@@ -1,29 +1,29 @@
 import MapModule from "./map_module";
 
-function MapRuntimeModule(emscriptenApi) {
+export function MapRuntimeModule(emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _ready = false;
 
-    this.Pause = function() {
-        if(_ready){
+    this.Pause = () => {
+        if (_ready) {
             _emscriptenApi.mapRuntimeApi.onPause();
         }
     };
 
-    this.Resume = function() {
-        if(_ready){
+    this.Resume = () => {
+        if (_ready) {
             _emscriptenApi.mapRuntimeApi.onResume();
         }
     };
 
-    this.Remove = function() {
-        if(_ready){
+    this.Remove = () => {
+        if (_ready) {
             _emscriptenApi.mapRuntimeApi.onRemove();
         }
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
     };
 }

--- a/src/private/polygon_module.js
+++ b/src/private/polygon_module.js
@@ -1,6 +1,6 @@
 import MapModule from "./map_module";
 
-function PolygonsModule(emscriptenApi) {
+export function PolygonsModule(emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _polygonIdToPolygons = {};
@@ -8,43 +8,41 @@ function PolygonsModule(emscriptenApi) {
     var _ready = false;
 
 
-    var _createPendingPolygons = function() {
-        _pendingPolygons.forEach(function(polygon) {
+    var _createPendingPolygons = () => {
+        _pendingPolygons.forEach(function (polygon) {
             _createAndAdd(polygon);
         });
         _pendingPolygons = [];
     };
 
-    var _createAndAdd = function(polygon) {
+    var _createAndAdd = (polygon) => {
         var polygonId = _emscriptenApi.geofenceApi.createGeofence(polygon.getPoints(), polygon.getHoles(), polygon._getConfig());
         _polygonIdToPolygons[polygonId] = polygon;
         return polygonId;
     };
 
-    this.addPolygon = function(polygon) {
+    this.addPolygon = (polygon) => {
         if (_ready) {
             _createAndAdd(polygon);
-    	}
+        }
         else {
             _pendingPolygons.push(polygon);
         }
     };
 
-    this.removePolygon = function(polygon) {
+    this.removePolygon = (polygon) => {
 
         if (!_ready) {
             var index = _pendingPolygons.indexOf(polygon);
             if (index > -1) {
                 _pendingPolygons.splice(index, 1);
             }
-            return; 
+            return;
         }
 
-        var polygonId = Object.keys(_polygonIdToPolygons).find(function(key) { 
-                return _polygonIdToPolygons[key] === polygon;
-            }
+        var polygonId = Object.keys(_polygonIdToPolygons).find((key) => _polygonIdToPolygons[key] === polygon
         );
-        
+
         if (polygonId === undefined) {
             return;
         }
@@ -56,17 +54,17 @@ function PolygonsModule(emscriptenApi) {
     this.onUpdate = function() {
         if (_ready) {
 
-            Object.keys(_polygonIdToPolygons).forEach(function(polygonId) {
-                var polygon = _polygonIdToPolygons[polygonId];
-                if (polygon._colorNeedsChanged()) {
-                    _emscriptenApi.geofenceApi.setGeofenceColor(polygonId, polygon.getColor());
-                    polygon._onColorChanged();
-                }
-            });
+            Object.keys(_polygonIdToPolygons).forEach((polygonId) => {
+                    var polygon = _polygonIdToPolygons[polygonId];
+                    if (polygon._colorNeedsChanged()) {
+                        _emscriptenApi.geofenceApi.setGeofenceColor(polygonId, polygon.getColor());
+                        polygon._onColorChanged();
+                    }
+                });
 		}
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
         _createPendingPolygons();
     };

--- a/src/private/polygon_module.js
+++ b/src/private/polygon_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 function PolygonsModule(emscriptenApi) {
 
@@ -71,6 +71,7 @@ function PolygonsModule(emscriptenApi) {
         _createPendingPolygons();
     };
 }
+
 PolygonsModule.prototype = MapModule;
 
-module.exports = PolygonsModule;
+export default PolygonsModule;

--- a/src/private/polygon_shim.js
+++ b/src/private/polygon_shim.js
@@ -68,6 +68,4 @@ export const PolygonShim = Polygon.extend({
     }
 });
 
-export const polygonShim = function (latlng, options) {
-	return new PolygonShim(latlng, options);
-};
+export const polygonShim = (latlng, options) => new PolygonShim(latlng, options);

--- a/src/private/polygon_shim.js
+++ b/src/private/polygon_shim.js
@@ -1,16 +1,16 @@
-var L = require("leaflet");
-var elevationMode = require("./elevation_mode.js");
+import { Polygon } from "leaflet";
+import { ElevationModeType, isValidElevationMode } from "./elevation_mode.js";
 
-var PolygonShim = L.Polygon.extend({
+export const PolygonShim = Polygon.extend({
 	options: {
         elevation: 0,
-        elevationMode: elevationMode.ElevationModeType.HEIGHT_ABOVE_GROUND
+        elevationMode: ElevationModeType.HEIGHT_ABOVE_GROUND
 	},
 		
 	_projectLatlngs: function (latlngs, result, projectedBounds) {
 		if(!this._map._projectLatlngs(this, latlngs, result, projectedBounds))
 		{			
-			L.Polygon.prototype._projectLatlngs.call(this, latlngs, result, projectedBounds);
+			Polygon.prototype._projectLatlngs.call(this, latlngs, result, projectedBounds);
 		}
 	},
 
@@ -28,7 +28,7 @@ var PolygonShim = L.Polygon.extend({
 	},
 
     _convertLatLngs: function (latlngs) {
-        var result = L.Polygon.prototype._convertLatLngs.call(this, latlngs);
+        var result = Polygon.prototype._convertLatLngs.call(this, latlngs);
 
         if(this._map) {
             this._map._createPointMapping(this);
@@ -52,7 +52,7 @@ var PolygonShim = L.Polygon.extend({
     },
 
     setElevationMode: function(mode) {
-        if (elevationMode.isValidElevationMode(mode)) {
+        if (isValidElevationMode(mode)) {
             this.options.elevationMode = mode;
 
             if (this._map !== null) {
@@ -68,11 +68,6 @@ var PolygonShim = L.Polygon.extend({
     }
 });
 
-var polygonShim = function (latlng, options) {
+export const polygonShim = function (latlng, options) {
 	return new PolygonShim(latlng, options);
-};
-
-module.exports = {
-    PolygonShim: PolygonShim,
-    polygonShim: polygonShim
 };

--- a/src/private/polyline_module.js
+++ b/src/private/polyline_module.js
@@ -1,6 +1,6 @@
 import MapModule from "./map_module";
 
-function PolylineModule(emscriptenApi) {
+export function PolylineModule(emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _polylineIdToPolyline = {};
@@ -8,20 +8,20 @@ function PolylineModule(emscriptenApi) {
     var _ready = false;
 
 
-    var _createPendingPolylines = function() {
-        _pendingPolylines.forEach(function(polyline) {
-            _createAndAdd(polyline);
-        });
+    var _createPendingPolylines = () => {
+        _pendingPolylines.forEach((polyline) => {
+                _createAndAdd(polyline);
+            });
         _pendingPolylines = [];
     };
 
-    var _createAndAdd = function(polyline) {
+    var _createAndAdd = (polyline) => {
         var polylineId = _emscriptenApi.polylineApi.createPolyline(polyline);
         _polylineIdToPolyline[polylineId] = polyline;
         return polylineId;
     };
 
-    this.addPolyline = function(polyline) {
+    this.addPolyline = (polyline) => {
         if (_ready) {
             _createAndAdd(polyline);
         }
@@ -30,7 +30,7 @@ function PolylineModule(emscriptenApi) {
         }
     };
 
-    this.removePolyline = function(polyline) {
+    this.removePolyline = (polyline) => {
 
         if (!_ready) {
             var index = _pendingPolylines.indexOf(polyline);
@@ -40,9 +40,7 @@ function PolylineModule(emscriptenApi) {
             return;
         }
 
-        var polylineId = Object.keys(_polylineIdToPolyline).find(function(key) {
-                return _polylineIdToPolyline[key] === polyline;
-            }
+        var polylineId = Object.keys(_polylineIdToPolyline).find((key) => _polylineIdToPolyline[key] === polyline
         );
 
         if (polylineId === undefined) {
@@ -53,16 +51,16 @@ function PolylineModule(emscriptenApi) {
         delete _polylineIdToPolyline[polylineId];
     };
 
-    this.onUpdate = function() {
+    this.onUpdate = () => {
         if (_ready) {
-            Object.keys(_polylineIdToPolyline).forEach(function(polylineId) {
-                var polyline = _polylineIdToPolyline[polylineId];
-                _emscriptenApi.polylineApi.updateNativeState(polylineId, polyline);
-            });
+            Object.keys(_polylineIdToPolyline).forEach((polylineId) => {
+                    var polyline = _polylineIdToPolyline[polylineId];
+                    _emscriptenApi.polylineApi.updateNativeState(polylineId, polyline);
+                });
         }
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
         _createPendingPolylines();
     };

--- a/src/private/polyline_module.js
+++ b/src/private/polyline_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 function PolylineModule(emscriptenApi) {
 
@@ -67,6 +67,7 @@ function PolylineModule(emscriptenApi) {
         _createPendingPolylines();
     };
 }
+
 PolylineModule.prototype = MapModule;
 
-module.exports = PolylineModule;
+export default PolylineModule;

--- a/src/private/polyline_shim.js
+++ b/src/private/polyline_shim.js
@@ -67,6 +67,5 @@ export const PolylineShim = Polyline.extend({
     }
 });
 
-export const polylineShim = function (latlng, options) {
-	return new PolylineShim(latlng, options);
-};
+export const polylineShim = (latlng, options) => new PolylineShim(latlng, options);
+

--- a/src/private/polyline_shim.js
+++ b/src/private/polyline_shim.js
@@ -1,23 +1,23 @@
-var L = require("leaflet");
-var elevationMode = require("./elevation_mode.js");
+import { Polyline } from "leaflet";
+import { ElevationModeType, isValidElevationMode } from "./elevation_mode.js";
 
-var PolylineShim = L.Polyline.extend({
+export const PolylineShim = Polyline.extend({
 	options: {
         elevation: 0,
-        elevationMode: elevationMode.ElevationModeType.HEIGHT_ABOVE_GROUND
+        elevationMode: ElevationModeType.HEIGHT_ABOVE_GROUND
     },
 
 	_projectLatlngs: function (latlngs, result, projectedBounds) {		
 		if(!this._map._projectLatlngs(this, latlngs, result, projectedBounds))
 		{		
-			L.Polyline.prototype._projectLatlngs.call(this, latlngs, result, projectedBounds);
+			Polyline.prototype._projectLatlngs.call(this, latlngs, result, projectedBounds);
 		}
 	},
 
 	// @method setLatLngs(latlngs: LatLng[]): this
 	// Replaces all the points in the polyline with the given array of geographical points.
 	setLatLngs: function (latlngs) {				
-		var redraw = L.Polyline.prototype.setLatLngs.call(this, latlngs);
+		var redraw = Polyline.prototype.setLatLngs.call(this, latlngs);
 
 		if(this._map) {
 			this._map._createPointMapping(this);
@@ -27,7 +27,7 @@ var PolylineShim = L.Polyline.extend({
 	},
 
     addLatLng: function (latlng, latlngs) {
-        var redraw = L.Polyline.prototype.addLatLng.call(this, latlngs);
+        var redraw = Polyline.prototype.addLatLng.call(this, latlngs);
 
         if(this._map) {
             this._map._createPointMapping(this);
@@ -51,7 +51,7 @@ var PolylineShim = L.Polyline.extend({
     },
 
     setElevationMode: function(mode) {
-        if (elevationMode.isValidElevationMode(mode)) {
+        if (isValidElevationMode(mode)) {
             this.options.elevationMode = mode;
 
             if (this._map !== null) {
@@ -67,11 +67,6 @@ var PolylineShim = L.Polyline.extend({
     }
 });
 
-var polylineShim = function (latlng, options) {
+export const polylineShim = function (latlng, options) {
 	return new PolylineShim(latlng, options);
-};
-
-module.exports = {
-    PolylineShim: PolylineShim,
-    polylineShim: polylineShim
 };

--- a/src/private/precache_module.js
+++ b/src/private/precache_module.js
@@ -1,6 +1,6 @@
-var MapModule = require("./map_module");
-var IdToObjectMap = require("./id_to_object_map");
-var PrecacheOperationResult = require("../public/precaching/precache_operation_result");
+import MapModule from "./map_module";
+import IdToObjectMap from "./id_to_object_map";
+import PrecacheOperationResult from "../public/precaching/precache_operation_result";
 
 var PrecacheOperation = function(operation) {
     var _operation = operation;
@@ -147,6 +147,7 @@ var PrecacheModule = function(emscriptenApi) {
     };
 
 };
+
 PrecacheModule.prototype = MapModule;
 
-module.exports = PrecacheModule;
+export default PrecacheModule;

--- a/src/private/precache_module.js
+++ b/src/private/precache_module.js
@@ -2,98 +2,90 @@ import MapModule from "./map_module";
 import IdToObjectMap from "./id_to_object_map";
 import PrecacheOperationResult from "../public/precaching/precache_operation_result";
 
-var PrecacheOperation = function(operation) {
+function PrecacheOperation (operation) {
     var _operation = operation;
 
     this.cancel = function() {
         _operation.cancel();
     };
-};
+}
 
 
-var InternalPrecacheOperation = function(centre, radius, completionCallback) {
+function InternalPrecacheOperation (centre, radius, completionCallback) {
     var _centre = L.latLng(centre);
     var _radius = radius;
     var _completionCallback = completionCallback;
     var _cancelled = false;
 
-    var _executeCompletionCallback = function(success) {
+    var _executeCompletionCallback = (success) => {
         _completionCallback(new PrecacheOperationResult(success));
     };
 
-    this.getCentre = function() {
-        return _centre;
-    };
+    this.getCentre = () => _centre;
 
-    this.getRadius = function() {
-        return _radius;
-    };
+    this.getRadius = () => _radius;
 
-    this.cancel = function() {
+    this.cancel = () => {
         _cancelled = true;
     };
 
-    this.isCancelled = function() {
-        return _cancelled;
-    };
+    this.isCancelled = () => _cancelled;
 
-    this.notifyComplete = function() {
+    this.notifyComplete = () => {
         _executeCompletionCallback(true);
     };
 
-    this.notifyCancelled = function() {
+    this.notifyCancelled = () => {
         _executeCompletionCallback(false);
     };
-};
+}
 
-var PrecacheModule = function(emscriptenApi) {
+function PrecacheModule (emscriptenApi) {
     var _emscriptenApi = emscriptenApi;
     var _operations = new IdToObjectMap();
     var _pendingOperations = [];
     var _ready = false;
 
-    var _beginPrecacheOperation = function(operation) {
-    var operationId = _emscriptenApi.precacheApi.beginPrecacheOperation(operation);
+    var _beginPrecacheOperation = (operation) => {
+        var operationId = _emscriptenApi.precacheApi.beginPrecacheOperation(operation);
         _operations.insertObject(operationId, operation);
 
         return operationId;
     };
 
-    var _beginAllPrecacheOperations = function() {
-        _pendingOperations.forEach(function(operation) {
-            if (operation.isCancelled()) {
-                operation.notifyCancelled();
-            }
-            else {
-                _beginPrecacheOperation(operation);
-            }
-        });
+    var _beginAllPrecacheOperations = () => {
+        _pendingOperations.forEach((operation) => {
+                if (operation.isCancelled()) {
+                    operation.notifyCancelled();
+                }
+                else {
+                    _beginPrecacheOperation(operation);
+                }
+            });
 
         _pendingOperations = [];
     };
 
-    var _cancelOperations = function(cancelledIds) {
-        cancelledIds.forEach(function(operationId) {
-        _emscriptenApi.precacheApi.cancelPrecacheOperation(operationId);
-        });
+    var _cancelOperations = (cancelledIds) => {
+        cancelledIds.forEach((operationId) => {
+                _emscriptenApi.precacheApi.cancelPrecacheOperation(operationId);
+            });
     };
 
-    var _onPrecacheOperationCompleted = function(operationId) {
+    var _onPrecacheOperationCompleted = (operationId) => {
         var operation = _operations.removeObjectById(operationId);
         operation.notifyComplete();
     };
 
-    var _onPrecacheOperationCancelled = function(operationId) {
+    var _onPrecacheOperationCancelled = (operationId) => {
         var operation = _operations.removeObjectById(operationId);
         operation.notifyCancelled();
     };
 
-    var _getMaximumPrecacheRadius = function() {
-        // :TODO: Fix DRY fail causing this to exist in both EegeoPrecacheApi::MaxPrecacheRadius and here.
-        return 16000.0;
-    };
+    // :TODO: Fix DRY fail causing this to exist in both EegeoPrecacheApi::MaxPrecacheRadius and here.
+    var _getMaximumPrecacheRadius = () => 16000.0;
 
-    var _validatePrecacheParameters = function(center, radius) {
+    var _validatePrecacheParameters = (center, radius) => {
         if (radius > _getMaximumPrecacheRadius() || radius <= 0.0) {
             return new Error("radius outside of valid (0.0, " + _getMaximumPrecacheRadius() + "] range.");
         }
@@ -101,11 +93,9 @@ var PrecacheModule = function(emscriptenApi) {
         return null;
     };
 
-    this.getMaximumPrecacheRadius = function() {
-        return _getMaximumPrecacheRadius();
-    };
+    this.getMaximumPrecacheRadius = () => _getMaximumPrecacheRadius();
 
-    this.precache = function(center, radius, callbackFunction) {
+    this.precache = (center, radius, callbackFunction) => {
         var parameterValidationError = _validatePrecacheParameters(center, radius);
 
         if (parameterValidationError !== null) {
@@ -126,13 +116,13 @@ var PrecacheModule = function(emscriptenApi) {
         return precacheOperation;
     };
 
-    this.onInitialized = function () {
+    this.onInitialized = () => {
         _ready = true;
         _emscriptenApi.precacheApi.registerCallbacks(_onPrecacheOperationCompleted, _onPrecacheOperationCancelled);
         _beginAllPrecacheOperations();
     };
 
-    this.onUpdate = function(dt) {
+    this.onUpdate = (dt) => {
         if (!_ready) {
             return;
         }
@@ -145,8 +135,7 @@ var PrecacheModule = function(emscriptenApi) {
         });
         _cancelOperations(cancelledOperations);
     };
-
-};
+}
 
 PrecacheModule.prototype = MapModule;
 

--- a/src/private/prop_module.js
+++ b/src/private/prop_module.js
@@ -1,5 +1,5 @@
-var MapModule = require("./map_module");
-var IdToObjectMap = require("./id_to_object_map");
+import MapModule from "./map_module";
+import IdToObjectMap from "./id_to_object_map";
 
 var PropModule = function(emscriptenApi) {
     var _emscriptenApi = emscriptenApi;
@@ -231,4 +231,5 @@ var PropModule = function(emscriptenApi) {
 var PropPrototype = L.extend({}, MapModule, L.Mixin.Events);
 
 PropModule.prototype = PropPrototype;
-module.exports = PropModule;
+
+export default PropModule;

--- a/src/private/prop_module.js
+++ b/src/private/prop_module.js
@@ -1,7 +1,7 @@
 import MapModule from "./map_module";
 import IdToObjectMap from "./id_to_object_map";
 
-var PropModule = function(emscriptenApi) {
+export function PropModule (emscriptenApi) {
     var _emscriptenApi = emscriptenApi;
     var _pendingProps = [];
     var _props = new IdToObjectMap();
@@ -11,9 +11,7 @@ var PropModule = function(emscriptenApi) {
     var _hasPendingServiceUrl = false;
     var _ready = false;
 
-    var _this = this;
-
-    var _createAndAdd = function(prop) {
+    var _createAndAdd = (prop) => {
         var propId = _emscriptenApi.propsApi.createProp(
             prop.getIndoorMapId(),
             prop.getIndoorMapFloorId(),
@@ -27,7 +25,7 @@ var PropModule = function(emscriptenApi) {
         _props.insertObject(propId, prop);
     };
 
-    var _createAndAddArray = function(propArray) {
+    var _createAndAddArray = (propArray) => {
         var indoorMapIds = [];
         var indoorMapFloorIds = [];
         var names = [];
@@ -54,12 +52,12 @@ var PropModule = function(emscriptenApi) {
         var propIds = _emscriptenApi.propsApi.createProps(indoorMapIds, indoorMapFloorIds, names, latitudes, longitudes, elevations, elevationModes, headings, geometryIds);
 
         for (propIndex = 0; propIndex < propIds.length; ++propIndex) {
-            var propId  = propIds[propIndex];
+            var propId = propIds[propIndex];
             _props.insertObject(propId, propArray[propIndex]);
         }
     };
 
-    var _createPendingProps = function() {
+    var _createPendingProps = () => {
         if (_pendingProps.length === 0) {
             return;
         }
@@ -67,18 +65,18 @@ var PropModule = function(emscriptenApi) {
         _pendingProps = [];
     };
 
-    var _executeIndoorMapEntitySetPropsLoadedCallbacks = function(indoorMapId, floorId) {
-        _this.fire("indoormapentitysetpropsloaded", {indoorMapId: indoorMapId, floorId: floorId});
+    var _executeIndoorMapEntitySetPropsLoadedCallbacks = (indoorMapId, floorId) => {
+        this.fire("indoormapentitysetpropsloaded", {indoorMapId: indoorMapId, floorId: floorId});
     };
 
-    var _executeIndoorMapPopulationRequestCompletedCallbacks = function(succeeded, httpStatusCode) {
-        _this.fire("indoormappopulationrequestcomplete", {
+    var _executeIndoorMapPopulationRequestCompletedCallbacks = (succeeded, httpStatusCode) => {
+        this.fire("indoormappopulationrequestcomplete", {
             succeeded: (succeeded === 0 ? false : true),
             httpStatusCode: httpStatusCode
         });
     };
 
-    this.addProp = function(prop) {
+    this.addProp = (prop) => {
         if (_ready) {
             _createAndAdd(prop);
         }
@@ -87,7 +85,7 @@ var PropModule = function(emscriptenApi) {
         }
     };
 
-    this.addProps = function(propArray) {
+    this.addProps = (propArray) => {
         if (_ready) {
             _createAndAddArray(propArray);
         }
@@ -96,12 +94,11 @@ var PropModule = function(emscriptenApi) {
         }
     };
 
-    this.removeProp = function(prop) {
+    this.removeProp = (prop) => {
         if (_ready && _pendingProps.length === 0) {
             var propId = _props.idForObject(prop);
 
-            if (propId !== null)
-            {
+            if (propId !== null) {
                 _emscriptenApi.propsApi.destroyProp(propId);
                 _props.removeObjectById(propId);
             }
@@ -115,7 +112,7 @@ var PropModule = function(emscriptenApi) {
         }
     };
 
-    this.removeProps = function(propArray) {
+    this.removeProps = (propArray) => {
         var propIndex = 0;
 
         if (_ready && _pendingProps.length === 0) {
@@ -140,7 +137,7 @@ var PropModule = function(emscriptenApi) {
         }
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
         _createPendingProps();
 
@@ -156,40 +153,39 @@ var PropModule = function(emscriptenApi) {
         _emscriptenApi.propsApi.onInitialized();
     };
 
-    this.onUpdate = function(dt) {
+    this.onUpdate = (dt) => {
         if (_ready) {
 
-            _props.forEachItem(function(propId, prop) {
+            _props.forEachItem((propId, prop) => {
+                    if (prop._locationNeedsChanged()) {
+                        _emscriptenApi.propsApi.setLocation(propId, prop.getLocation().lat, prop.getLocation().lng);
+                        prop._onLocationChanged();
+                    }
 
-                if (prop._locationNeedsChanged()) {
-                    _emscriptenApi.propsApi.setLocation(propId, prop.getLocation().lat, prop.getLocation().lng);
-                    prop._onLocationChanged();
-                }
+                    if (prop._headingDegreesNeedsChanged()) {
+                        _emscriptenApi.propsApi.setHeadingDegrees(propId, prop.getHeadingDegrees());
+                        prop._onHeadingDegreesChanged();
+                    }
 
-                if (prop._headingDegreesNeedsChanged()) {
-                    _emscriptenApi.propsApi.setHeadingDegrees(propId, prop.getHeadingDegrees());
-                    prop._onHeadingDegreesChanged();
-                }
+                    if (prop._elevationNeedsChanged()) {
+                        _emscriptenApi.propsApi.setElevation(propId, prop.getElevation());
+                        prop._onElevationChanged();
+                    }
 
-                if (prop._elevationNeedsChanged()) {
-                    _emscriptenApi.propsApi.setElevation(propId, prop.getElevation());
-                    prop._onElevationChanged();
-                }
+                    if (prop._elevationModeNeedsChanged()) {
+                        _emscriptenApi.propsApi.setElevationMode(propId, prop.getElevationMode());
+                        prop._onElevationModeChanged();
+                    }
 
-                if (prop._elevationModeNeedsChanged()) {
-                    _emscriptenApi.propsApi.setElevationMode(propId, prop.getElevationMode());
-                    prop._onElevationModeChanged();
-                }
-
-                if (prop._geometryIdNeedsChanged()) {
-                    _emscriptenApi.propsApi.setGeometryId(propId, prop.getGeometryId());
-                    prop._onGeometryIdChanged();
-                }
-            });
+                    if (prop._geometryIdNeedsChanged()) {
+                        _emscriptenApi.propsApi.setGeometryId(propId, prop.getGeometryId());
+                        prop._onGeometryIdChanged();
+                    }
+                });
         }
     };
 
-    this.setAutomaticIndoorMapPopulationEnabled = function(enabled) {
+    this.setAutomaticIndoorMapPopulationEnabled = (enabled) => {
         if (_ready) {
             _emscriptenApi.propsApi.setAutomaticIndoorMapPopulationEnabled(enabled);
         }
@@ -199,7 +195,7 @@ var PropModule = function(emscriptenApi) {
         }
     };
 
-    this.isAutomaticIndoorMapPopulationEnabled = function() {
+    this.isAutomaticIndoorMapPopulationEnabled = () => {
         if (_ready) {
             return _emscriptenApi.propsApi.isAutomaticIndoorMapPopulationEnabled();
         }
@@ -208,17 +204,17 @@ var PropModule = function(emscriptenApi) {
         }
     };
 
-    this.setIndoorMapPopulationServiceUrl = function(serviceUrl) {
+    this.setIndoorMapPopulationServiceUrl = (serviceUrl) => {
         if (_ready) {
             return _emscriptenApi.propsApi.setIndoorMapPopulationServiceUrl(serviceUrl);
-        }   
+        }
         else {
             _pendingServiceUrl = serviceUrl;
             _hasPendingServiceUrl = true;
         }
     };
 
-    this.getIndoorMapEntitySetProps = function(indoorMapId, floorId) {
+    this.getIndoorMapEntitySetProps = (indoorMapId, floorId) => {
         if (_ready) {
             return _emscriptenApi.propsApi.tryGetIndoorMapEntitySetProps(indoorMapId, floorId);
         }
@@ -226,7 +222,7 @@ var PropModule = function(emscriptenApi) {
             return null;
         }
     };
-};
+}
 
 var PropPrototype = L.extend({}, MapModule, L.Mixin.Events);
 

--- a/src/private/rectangle_shim.js
+++ b/src/private/rectangle_shim.js
@@ -1,23 +1,23 @@
-var L = require("leaflet");
-var elevationMode = require("./elevation_mode.js");
+import { Rectangle } from "leaflet";
+import { ElevationModeType, isValidElevationMode } from "./elevation_mode.js";
 
-var RectangleShim = L.Rectangle.extend({
+export const RectangleShim = Rectangle.extend({
 	options: {
         elevation: 0,
-        elevationMode: elevationMode.ElevationModeType.HEIGHT_ABOVE_GROUND
+        elevationMode: ElevationModeType.HEIGHT_ABOVE_GROUND
 	},
 	
 	_projectLatlngs: function (latlngs, result, projectedBounds) {						
 		if(!this._map._projectLatlngs(this, latlngs, result, projectedBounds))
 		{			
-			L.Rectangle.prototype._projectLatlngs.call(this, latlngs, result, projectedBounds);
+			Rectangle.prototype._projectLatlngs.call(this, latlngs, result, projectedBounds);
 		}
 	},
 
 	// @method setLatLngs(latlngs: LatLng[]): this
 	// Replaces all the points in the polyline with the given array of geographical points.
 	setLatLngs: function (latlngs) {
-		var redraw = L.Rectangle.prototype.setLatLngs.call(this, latlngs);
+		var redraw = Rectangle.prototype.setLatLngs.call(this, latlngs);
 		
 		if(this._map) {
 			this._map._createPointMapping(this);
@@ -41,7 +41,7 @@ var RectangleShim = L.Rectangle.extend({
     },
 
     setElevationMode: function(mode) {
-        if (elevationMode.isValidElevationMode(mode)) {
+        if (isValidElevationMode(mode)) {
             this.options.elevationMode = mode;
 
             if (this._map !== null) {
@@ -57,11 +57,6 @@ var RectangleShim = L.Rectangle.extend({
     }
 });
 
-var rectangleShim = function (latlng, options) {
+export const rectangleShim = function (latlng, options) {
 	return new RectangleShim(latlng, options);
-};
-
-module.exports = {
-    RectangleShim: RectangleShim,
-    rectangleShim: rectangleShim
 };

--- a/src/private/rectangle_shim.js
+++ b/src/private/rectangle_shim.js
@@ -57,6 +57,4 @@ export const RectangleShim = Rectangle.extend({
     }
 });
 
-export const rectangleShim = function (latlng, options) {
-	return new RectangleShim(latlng, options);
-};
+export const rectangleShim = (latlng, options) => new RectangleShim(latlng, options);

--- a/src/private/rendering_module.js
+++ b/src/private/rendering_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 
 function RenderingModule(emscriptenApi, clearColor) {
@@ -74,6 +74,7 @@ function RenderingModule(emscriptenApi, clearColor) {
     };
 
 }
+
 RenderingModule.prototype = MapModule;
 
-module.exports = RenderingModule;
+export default RenderingModule;

--- a/src/private/rendering_module.js
+++ b/src/private/rendering_module.js
@@ -1,24 +1,21 @@
 import MapModule from "./map_module";
 
-
-function RenderingModule(emscriptenApi, clearColor) {
+export function RenderingModule(emscriptenApi, clearColor) {
 
     var _emscriptenApi = emscriptenApi;
     var _isMapCollapsed = false;
     var _clearColor = clearColor;
     var _ready = false;
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _emscriptenApi.renderingApi.setClearColor(_clearColor);
         _emscriptenApi.renderingApi.setMapCollapsed(_isMapCollapsed);
         _ready = true;
     };
 
-    this.ready = function() {
-        return _ready;
-    };
+    this.ready = () => _ready;
 
-    this.setMapCollapsed = function(isMapCollapsed) {
+    this.setMapCollapsed = (isMapCollapsed) => {
         _isMapCollapsed = isMapCollapsed;
         if (!_ready) {
             return;
@@ -26,11 +23,9 @@ function RenderingModule(emscriptenApi, clearColor) {
         _emscriptenApi.renderingApi.setMapCollapsed(_isMapCollapsed);
     };
 
-    this.isMapCollapsed = function(isMapCollapsed) {
-        return _isMapCollapsed;
-    },
+    this.isMapCollapsed = () => _isMapCollapsed,
 
-    this.setClearColor = function(clearColor) {
+    this.setClearColor = (clearColor) => {
         _clearColor = clearColor;
         if (!_ready) {
             return;
@@ -38,41 +33,40 @@ function RenderingModule(emscriptenApi, clearColor) {
         _emscriptenApi.renderingApi.setClearColor(_clearColor);
     };
 
-    this.getCameraRelativePosition = function(latLng) {
+    this.getCameraRelativePosition = (latLng) => {
         if (!_ready) {
             return null;
         }
         return _emscriptenApi.renderingApi.getCameraRelativePosition(latLng);
     };
 
-    this.getNorthFacingOrientationMatrix = function(latLng) {
+    this.getNorthFacingOrientationMatrix = (latLng) => {
         if (!_ready) {
             return null;
         }
         return _emscriptenApi.renderingApi.getNorthFacingOrientationMatrix(latLng);
     };
 
-    this.getCameraProjectionMatrix = function() {
+    this.getCameraProjectionMatrix = () => {
         if (!_ready) {
             return null;
         }
         return _emscriptenApi.renderingApi.getCameraProjectionMatrix();
     };
 
-    this.getCameraOrientationMatrix = function() {
+    this.getCameraOrientationMatrix = () => {
         if (!_ready) {
             return null;
         }
         return _emscriptenApi.renderingApi.getCameraOrientationMatrix();
     };
 
-    this.getLightingData = function() {
+    this.getLightingData = () => {
         if (!_ready) {
             return null;
         }
         return _emscriptenApi.renderingApi.getLightingData();
     };
-
 }
 
 RenderingModule.prototype = MapModule;

--- a/src/private/routing_module.js
+++ b/src/private/routing_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 var RoutingModule = function(apiKey, indoorsModule) {
 
@@ -150,4 +150,4 @@ var RoutingModule = function(apiKey, indoorsModule) {
 
 RoutingModule.prototype = MapModule;
 
-module.exports = RoutingModule;
+export default RoutingModule;

--- a/src/private/routing_module.js
+++ b/src/private/routing_module.js
@@ -1,22 +1,20 @@
 import MapModule from "./map_module";
 
-var RoutingModule = function(apiKey, indoorsModule) {
+export function RoutingModule (apiKey, indoorsModule) {
 
     var _urlRoot = "https://routing.wrld3d.com/v1/";
     var _apiKey = apiKey;
     var _indoorsModule = indoorsModule;
 
-    var _parseMetadataTag = function(metadata, tag) {
+    var _parseMetadataTag = (metadata, tag) => {
         var decoratedTag = "{" + tag + ":";
         var occurrence = metadata.indexOf(decoratedTag);
 
-        if (occurrence !== -1)
-        {
+        if (occurrence !== -1) {
             var postTag = metadata.slice(occurrence + decoratedTag.length);
             var nextBracketIndex = postTag.indexOf("}");
 
-            if (nextBracketIndex !== -1)
-            {
+            if (nextBracketIndex !== -1) {
                 return postTag.substring(0, nextBracketIndex);
             }
         }
@@ -24,14 +22,12 @@ var RoutingModule = function(apiKey, indoorsModule) {
         return null;
     };
 
-    var _parseRouteSteps = function(routeSteps) {
+    var _parseRouteSteps = (routeSteps) => {
         var parsedSteps = [];
-        for (var i = 0; i < routeSteps.length; i++) 
-        {   
+        for (var i = 0; i < routeSteps.length; i++) {
             var metadata = routeSteps[i].name;
             var level = _parseMetadataTag(metadata, "level");
-            if (level === "multiple") 
-            {
+            if (level === "multiple") {
                 // skip route segments which change floor for now
                 continue;
             }
@@ -53,11 +49,10 @@ var RoutingModule = function(apiKey, indoorsModule) {
             }
             var stepGeometry = routeSteps[i]["geometry"]["coordinates"];
 
-            for (var j=0; j<stepGeometry.length; j++) 
-            {
-                var lonlat = stepGeometry[j];     
+            for (var j = 0; j < stepGeometry.length; j++) {
+                var lonlat = stepGeometry[j];
                 var latLon = [lonlat[1], lonlat[0]];
-                latLongPoints.push(latLon); 
+                latLongPoints.push(latLon);
             }
             routeStep.points = latLongPoints;
             parsedSteps.push(routeStep);
@@ -66,76 +61,64 @@ var RoutingModule = function(apiKey, indoorsModule) {
         return parsedSteps;
     };
 
-    var _parseRoutes = function(routingJson) {
-      var routes = routingJson["routes"];
-      var results = [];
+    var _parseRoutes = (routingJson) => {
+        var routes = routingJson["routes"];
+        var results = [];
 
-      for (var routeIndex = 0; routeIndex < routes.length; ++routeIndex)
-      {
-        var legs = routes[routeIndex]["legs"];
+        for (var routeIndex = 0; routeIndex < routes.length; ++routeIndex) {
+            var legs = routes[routeIndex]["legs"];
 
-        for (var legIndex = 0; legIndex < legs.length; ++legIndex)
-        {
-            var steps = legs[legIndex]["steps"]; 
-            var routeSteps = _parseRouteSteps(steps);
-            results.push(routeSteps);
+            for (var legIndex = 0; legIndex < legs.length; ++legIndex) {
+                var steps = legs[legIndex]["steps"];
+                var routeSteps = _parseRouteSteps(steps);
+                results.push(routeSteps);
+            }
         }
-      }
 
-      return results;
+        return results;
     };
 
-    var _routeParseHandler = function(routeLoadHandler, routeLoadErrorHandler) {
-        return function() {
-            var routeJson = JSON.parse(this.responseText);
+    var _routeParseHandler = (routeLoadHandler, routeLoadErrorHandler) => () => {
+        var routeJson = JSON.parse(this.responseText);
 
-            if (routeJson["code"] === "Ok")
-            {
-                var routes;
-                if ("type" in routeJson && routeJson["type"] === "multipart")
-                {
-                    var multiroute = routeJson["routes"];
-                    for (var index = 0; index < multiroute.length; ++index)
-                    {
-                        routes = _parseRoutes(multiroute[index]);
-                        routeLoadHandler(routes);
-                    }
-                }
-                else
-                {
-                    routes = _parseRoutes(routeJson);
+        if (routeJson["code"] === "Ok") {
+            var routes;
+            if ("type" in routeJson && routeJson["type"] === "multipart") {
+                var multiroute = routeJson["routes"];
+                for (var index = 0; index < multiroute.length; ++index) {
+                    routes = _parseRoutes(multiroute[index]);
                     routeLoadHandler(routes);
                 }
             }
-            else
-            {
-                if (routeLoadErrorHandler !== null && routeLoadErrorHandler !== undefined)
-                {
-                    routeLoadErrorHandler(routeJson);
-                }
+
+            else {
+                routes = _parseRoutes(routeJson);
+                routeLoadHandler(routes);
             }
-        };
+        }
+
+        else {
+            if (routeLoadErrorHandler !== null && routeLoadErrorHandler !== undefined) {
+                routeLoadErrorHandler(routeJson);
+            }
+        }
     };
 
-    var _cancelRequest = function(request) {
-        return function() {
-            request.abort();
-        };
+    var _cancelRequest = (request) => function () {
+        request.abort();
     };
 
-    this.getRoute = function(viaPoints, onLoadHandler, onErrorHandler, transportMode) { 
-        transportMode = transportMode || "walking";        
+    this.getRoute = (viaPoints, onLoadHandler, onErrorHandler, transportMode) => {
+        transportMode = transportMode || "walking";
         var url = _urlRoot + "route?loc=";
-        
-        for (var pointIndex = 0; pointIndex < viaPoints.length; ++pointIndex)
-        {
+
+        for (var pointIndex = 0; pointIndex < viaPoints.length; ++pointIndex) {
             url += viaPoints[pointIndex].join(",");
 
-            if (pointIndex < viaPoints.length - 1)
-            {
+            if (pointIndex < viaPoints.length - 1) {
                 url += "%3B";
             }
-            
+
         }
         url += "&apikey=" + _apiKey;
         url += "&limit=400";
@@ -146,7 +129,7 @@ var RoutingModule = function(apiKey, indoorsModule) {
         _indoorsModule.on("indoormapexit", _cancelRequest(request));
         request.send();
     };
-};
+}
 
 RoutingModule.prototype = MapModule;
 

--- a/src/private/themes_module.js
+++ b/src/private/themes_module.js
@@ -1,7 +1,7 @@
-var MapModule = require("./map_module");
-var Themes = require("../public/themes");
+import MapModule from "./map_module";
+import * as Themes from "../public/themes";
 
-var ThemesModule = function(emscriptenApi) {
+export const ThemesModule = function(emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _ready = false;
@@ -100,4 +100,4 @@ var ThemesModule = function(emscriptenApi) {
 
 ThemesModule.prototype = MapModule;
 
-module.exports = ThemesModule;
+export default ThemesModule;

--- a/src/private/themes_module.js
+++ b/src/private/themes_module.js
@@ -1,7 +1,7 @@
 import MapModule from "./map_module";
 import * as Themes from "../public/themes";
 
-export const ThemesModule = function(emscriptenApi) {
+export function ThemesModule (emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _ready = false;
@@ -13,7 +13,7 @@ export const ThemesModule = function(emscriptenApi) {
     var _shouldChangeTheme = false;
     var _shouldChangeState = false;
 
-    var _updateTheme = function() {
+    var _updateTheme = () => {
         if (!_ready) {
             return;
         }
@@ -29,35 +29,35 @@ export const ThemesModule = function(emscriptenApi) {
         }
     };
 
-    var _tryMatchBuiltIn = function(season, time, weather){
-        var getValues = function(obj) {
+    var _tryMatchBuiltIn = (season, time, weather) => {
+        var getValues = function (obj) {
             var values = [];
-            for(var key in obj) {
+            for (var key in obj) {
                 values.push(obj[key]);
             }
             return values;
         };
-        var caseInsensitiveMatchWithCollection = function(key, values) {
+        var caseInsensitiveMatchWithCollection = (key, values) => {
             var keyUpper = key.toUpperCase();
-            var matchedValue = values.find(function(item) {
+            var matchedValue = values.find(function (item) {
                 return keyUpper.localeCompare(item.toUpperCase()) === 0;
             });
             return matchedValue ? matchedValue : key;
         };
 
-        return { 
-            season: caseInsensitiveMatchWithCollection(season, getValues(Themes.season)), 
+        return {
+            season: caseInsensitiveMatchWithCollection(season, getValues(Themes.season)),
             time: caseInsensitiveMatchWithCollection(time, getValues(Themes.time)),
-            weather: caseInsensitiveMatchWithCollection(weather, getValues(Themes.weather)) 
-         };
+            weather: caseInsensitiveMatchWithCollection(weather, getValues(Themes.weather))
+        };
     };
 
-    var _onThemesStreamingCompleted = function() {
+    var _onThemesStreamingCompleted = () => {
         _ready = true;
         _updateTheme();
     };
     
-    this.setTheme = function(season, time, weather) {
+    this.setTheme = (season, time, weather) => {
         var themeInfo = _tryMatchBuiltIn(season, time, weather);
 
         if (themeInfo.season !== _season) {
@@ -67,36 +67,36 @@ export const ThemesModule = function(emscriptenApi) {
         if (themeInfo.time !== _time || themeInfo.weather !== _weather) {
             _shouldChangeState = true;
         }
-        
+
         _season = themeInfo.season;
         _time = themeInfo.time;
         _weather = themeInfo.weather;
         _updateTheme();
     };
 
-    this.setSeason = function(season) {
+    this.setSeason = (season) => {
         this.setTheme(season, _time, _weather);
     };
 
-    this.setTime = function(time) {
+    this.setTime = (time) => {
         this.setTheme(_season, time, _weather);
     };
 
-    this.setWeather = function(weather) {
-        this.setTheme(_season, _time, weather);        
+    this.setWeather = (weather) => {
+        this.setTheme(_season, _time, weather);
     };
 
-    this.setEnvironmentThemesManifest = function(environmentThemesManifest) {
+    this.setEnvironmentThemesManifest = (environmentThemesManifest) => {
         if (!_ready) {
             return;
         }
         _emscriptenApi.themesApi.setThemeManifest(environmentThemesManifest);
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _emscriptenApi.themesApi.registerStreamingCompletedCallback(_onThemesStreamingCompleted);
     };
-};
+}
 
 ThemesModule.prototype = MapModule;
 

--- a/src/private/version_module.js
+++ b/src/private/version_module.js
@@ -1,4 +1,4 @@
-var MapModule = require("./map_module");
+import MapModule from "./map_module";
 
 function VersionModule(emscriptenApi) {
 
@@ -24,6 +24,7 @@ function VersionModule(emscriptenApi) {
     };
 
 }
+
 VersionModule.prototype = MapModule;
 
-module.exports = VersionModule;
+export default VersionModule;

--- a/src/private/version_module.js
+++ b/src/private/version_module.js
@@ -1,25 +1,25 @@
 import MapModule from "./map_module";
 
-function VersionModule(emscriptenApi) {
+export function VersionModule(emscriptenApi) {
 
     var _emscriptenApi = emscriptenApi;
     var _ready = false;
 
-    this.getVersion = function() {
+    this.getVersion = () => {
         if (!_ready) {
             return null;
         }
         return _emscriptenApi.versionApi.getPlatformVersion();
     };
 
-    this.getVersionHash = function() {
+    this.getVersionHash = () => {
         if (!_ready) {
             return null;
         }
         return _emscriptenApi.versionApi.getPlatformVersionHash();
     };
 
-    this.onInitialized = function() {
+    this.onInitialized = () => {
         _ready = true;
     };
 

--- a/src/public/buildings/building_contour.js
+++ b/src/public/buildings/building_contour.js
@@ -1,29 +1,17 @@
-export const BuildingContour = function(
-    bottomAltitude,
-    topAltitude,
-    points
-    ) {
-    var _bottomAltitude = bottomAltitude;
-    var _topAltitude = topAltitude;
-    var _points = points;
+export function BuildingContour(bottomAltitude, topAltitude, points) {
+  var _bottomAltitude = bottomAltitude;
+  var _topAltitude = topAltitude;
+  var _points = points;
 
-    this.getBottomAltitude = function() {
-        return _bottomAltitude;
-    };
+  this.getBottomAltitude = () => _bottomAltitude;
 
-    this.getTopAltitude = function() {
-        return _topAltitude;
-    };
+  this.getTopAltitude = () => _topAltitude;
 
-    this.getPoints = function() {
-        return _points;
-    };
+  this.getPoints = () => _points;
 
-    this.toJson = function() {
-        return {
-            bottom_altitude: _bottomAltitude,
-            top_altitude: _topAltitude,
-            points: _points
-        };
-    };
-};
+  this.toJson = () => ({
+    bottom_altitude: _bottomAltitude,
+    top_altitude: _topAltitude,
+    points: _points,
+  });
+}

--- a/src/public/buildings/building_contour.js
+++ b/src/public/buildings/building_contour.js
@@ -1,4 +1,4 @@
-var BuildingContour = function(
+export const BuildingContour = function(
     bottomAltitude,
     topAltitude,
     points
@@ -27,6 +27,3 @@ var BuildingContour = function(
         };
     };
 };
-
-module.exports = BuildingContour;
-

--- a/src/public/buildings/building_dimensions.js
+++ b/src/public/buildings/building_dimensions.js
@@ -1,4 +1,4 @@
-var BuildingDimensions = function(
+export const BuildingDimensions = function(
     baseAltitude,
     topAltitude,
     centroid
@@ -28,6 +28,3 @@ var BuildingDimensions = function(
     };
 
 };
-
-module.exports = BuildingDimensions;
-

--- a/src/public/buildings/building_dimensions.js
+++ b/src/public/buildings/building_dimensions.js
@@ -1,30 +1,17 @@
-export const BuildingDimensions = function(
-    baseAltitude,
-    topAltitude,
-    centroid
-    ) {
-    var _baseAltitude = baseAltitude;
-    var _topAltitude = topAltitude;
-    var _centroid = centroid;
+export function BuildingDimensions(baseAltitude, topAltitude, centroid) {
+  var _baseAltitude = baseAltitude;
+  var _topAltitude = topAltitude;
+  var _centroid = centroid;
 
-    this.getBaseAltitude = function() {
-        return _baseAltitude;
-    };
+  this.getBaseAltitude = () => _baseAltitude;
 
-    this.getTopAltitude = function() {
-        return _topAltitude;
-    };
+  this.getTopAltitude = () => _topAltitude;
 
-    this.getCentroid = function() {
-        return _centroid;
-    };
+  this.getCentroid = () => _centroid;
 
-    this.toJson = function() {
-        return {
-            base_altitude: _baseAltitude,
-            top_altitude: _topAltitude,
-            centroid: _centroid
-        };
-    };
-
-};
+  this.toJson = () => ({
+    base_altitude: _baseAltitude,
+    top_altitude: _topAltitude,
+    centroid: _centroid,
+  });
+}

--- a/src/public/buildings/building_highlight.js
+++ b/src/public/buildings/building_highlight.js
@@ -1,22 +1,17 @@
 import { Vector4 } from "../space";
 
-export const BuildingHighlight = function(options) {
-
+export function BuildingHighlight (options) {
     var _options = options;
     var _id = null;
     var _map = null;
     var _color = options.getColor();
     var _buildingInformation = null;
 
-    this.getColor = function() {
-        return new Vector4(_color);
-    };
+    this.getColor = () => new Vector4(_color);
 
-    this.getOptions = function() {
-        return _options;
-    };
+    this.getOptions = () => _options;
 
-    this.setColor = function(color) {
+    this.setColor = (color) => {
         _color = new Vector4(color);
         if (_map !== null) {
             _map.buildings._getImpl().notifyBuildingHighlightChanged(this);
@@ -24,11 +19,9 @@ export const BuildingHighlight = function(options) {
         return this;
     };
 
-    this.getId = function() {
-        return _id;
-    };
+    this.getId = () => _id;
 
-    this.addTo = function(map) {
+    this.addTo = (map) => {
         if (_map !== null) {
             this.remove();
         }
@@ -37,7 +30,7 @@ export const BuildingHighlight = function(options) {
         return this;
     };
 
-    this.remove = function() {
+    this.remove = () => {
         if (_map !== null) {
             _map.buildings._getImpl().removeBuildingHighlight(this);
             _map = null;
@@ -45,19 +38,15 @@ export const BuildingHighlight = function(options) {
         return this;
     };
 
-    this._setNativeHandle = function(nativeId) {
+    this._setNativeHandle = (nativeId) => {
         _id = nativeId;
     };
 
-    this._setBuildingInformation = function(buildingInformation) {
+    this._setBuildingInformation = (buildingInformation) => {
         _buildingInformation = buildingInformation;
     };
 
-    this.getBuildingInformation = function() {
-        return _buildingInformation;
-    };
-};
+    this.getBuildingInformation = () => _buildingInformation;
+}
 
-export const buildingHighlight = function(options) {
-    return new BuildingHighlight(options);
-};
+export const buildingHighlight = (options) => new BuildingHighlight(options);

--- a/src/public/buildings/building_highlight.js
+++ b/src/public/buildings/building_highlight.js
@@ -1,6 +1,6 @@
-var space = require("../space");
+import { Vector4 } from "../space";
 
-var BuildingHighlight = function(options) {
+export const BuildingHighlight = function(options) {
 
     var _options = options;
     var _id = null;
@@ -9,7 +9,7 @@ var BuildingHighlight = function(options) {
     var _buildingInformation = null;
 
     this.getColor = function() {
-        return new space.Vector4(_color);
+        return new Vector4(_color);
     };
 
     this.getOptions = function() {
@@ -17,7 +17,7 @@ var BuildingHighlight = function(options) {
     };
 
     this.setColor = function(color) {
-        _color = new space.Vector4(color);
+        _color = new Vector4(color);
         if (_map !== null) {
             _map.buildings._getImpl().notifyBuildingHighlightChanged(this);
         }
@@ -58,12 +58,6 @@ var BuildingHighlight = function(options) {
     };
 };
 
-var buildingHighlight = function(options) {
+export const buildingHighlight = function(options) {
     return new BuildingHighlight(options);
 };
-
-module.exports = {
-    BuildingHighlight: BuildingHighlight,
-    buildingHighlight: buildingHighlight
-};
-

--- a/src/public/buildings/building_highlight_options.js
+++ b/src/public/buildings/building_highlight_options.js
@@ -2,64 +2,58 @@ import { Vector4 } from "../space";
 
 export const BuildingHighlightSelectionType = {
     SELECT_AT_LOCATION: "selectAtLocation",
-    SELECT_AT_SCEEN_POINT: "selectAtScreenPoint"
+    SELECT_AT_SCREEN_POINT: "selectAtScreenPoint"
 };
 
-
-export const BuildingHighlightOptions = function() {
-
-
+export function BuildingHighlightOptions () {
     var _selectionLocationLatLng = L.latLng([0.0, 0.0]);
     var _selectionScreenPoint = L.Point(0.0, 0.0);
     var _selectionMode = "selectAtLocation";
     var _color = [255, 255, 0, 128];
     var _informationOnly = false;
 
-    this.highlightBuildingAtLocation = function(latLng) {
+    this.highlightBuildingAtLocation = (latLng) => {
         _selectionMode = BuildingHighlightSelectionType.SELECT_AT_LOCATION;
         _selectionLocationLatLng = L.latLng(latLng);
         return this;
     };
 
-    this.highlightBuildingAtScreenPoint = function(screenPoint) {
+    this.highlightBuildingAtScreenPoint = (screenPoint) => {
         _selectionMode = BuildingHighlightSelectionType.SELECT_AT_SCREEN_POINT;
         _selectionScreenPoint = L.point(screenPoint);
         return this;
     };
 
-    this.color = function(color) {
+    this.color = (color) => {
         _color = color;
         return this;
     };
 
-    this.informationOnly = function() {
+    this.informationOnly = () => {
         _informationOnly = true;
         return this;
     };
 
-    this.getSelectionMode = function() {
+    this.getSelectionMode = () => {
         return _selectionMode;
     };
 
-    this.getSelectionLocation = function() {
+    this.getSelectionLocation = () => {
         return _selectionLocationLatLng;
     };
 
-    this.getSelectionScreenPoint = function() {
+    this.getSelectionScreenPoint = () => {
         return _selectionScreenPoint;
     };
 
-    this.getColor = function() {
+    this.getColor = () => {
         return new Vector4(_color);
     };
 
-    this.getIsInformationOnly = function() {
+    this.getIsInformationOnly = () => {
         return _informationOnly;
     };
+}
 
-};
-
-export const buildingHighlightOptions = function() {
-    return new BuildingHighlightOptions();
-};
+export const buildingHighlightOptions = () => new BuildingHighlightOptions();
 

--- a/src/public/buildings/building_highlight_options.js
+++ b/src/public/buildings/building_highlight_options.js
@@ -1,12 +1,12 @@
-var space = require("../space");
+import { Vector4 } from "../space";
 
-var BuildingHighlightSelectionType = {
+export const BuildingHighlightSelectionType = {
     SELECT_AT_LOCATION: "selectAtLocation",
     SELECT_AT_SCEEN_POINT: "selectAtScreenPoint"
 };
 
 
-var BuildingHighlightOptions = function() {
+export const BuildingHighlightOptions = function() {
 
 
     var _selectionLocationLatLng = L.latLng([0.0, 0.0]);
@@ -50,7 +50,7 @@ var BuildingHighlightOptions = function() {
     };
 
     this.getColor = function() {
-        return new space.Vector4(_color);
+        return new Vector4(_color);
     };
 
     this.getIsInformationOnly = function() {
@@ -59,13 +59,7 @@ var BuildingHighlightOptions = function() {
 
 };
 
-var buildingHighlightOptions = function() {
+export const buildingHighlightOptions = function() {
     return new BuildingHighlightOptions();
-};
-
-module.exports = {
-    BuildingHighlightOptions: BuildingHighlightOptions,
-    buildingHighlightOptions: buildingHighlightOptions,
-    BuildingHighlightSelectionType: BuildingHighlightSelectionType
 };
 

--- a/src/public/buildings/building_information.js
+++ b/src/public/buildings/building_information.js
@@ -1,30 +1,21 @@
-export const BuildingInformation = function(
-    buildingId,
-    buildingDimensions,
-    buildingContours
-    ) {
-    var _buildingId = buildingId;
-    var _buildingDimensions = buildingDimensions;
-    var _buildingContours = buildingContours;
+export function BuildingInformation(
+  buildingId,
+  buildingDimensions,
+  buildingContours
+) {
+  var _buildingId = buildingId;
+  var _buildingDimensions = buildingDimensions;
+  var _buildingContours = buildingContours;
 
-    this.getBuildingId = function() {
-        return _buildingId;
-    };
+  this.getBuildingId = () => _buildingId;
 
-    this.getBuildingDimensions = function() {
-        return _buildingDimensions;
-    };
+  this.getBuildingDimensions = () => _buildingDimensions;
 
-    this.getBuildingContours = function() {
-        return _buildingContours;
-    };
+  this.getBuildingContours = () => _buildingContours;
 
-    this.toJson = function() {
-        return {
-            building_id: _buildingId,
-            building_dimensions: _buildingDimensions.toJson(),
-            building_contours:_buildingContours.map(function(_x) { return _x.toJson();})
-        };
-    };
-
-};
+  this.toJson = () => ({
+    building_id: _buildingId,
+    building_dimensions: _buildingDimensions.toJson(),
+    building_contours: _buildingContours.map((_x) => _x.toJson()),
+  });
+}

--- a/src/public/buildings/building_information.js
+++ b/src/public/buildings/building_information.js
@@ -1,4 +1,4 @@
-var BuildingInformation = function(
+export const BuildingInformation = function(
     buildingId,
     buildingDimensions,
     buildingContours
@@ -28,6 +28,3 @@ var BuildingInformation = function(
     };
 
 };
-
-module.exports = BuildingInformation;
-

--- a/src/public/buildings/buildings.js
+++ b/src/public/buildings/buildings.js
@@ -1,5 +1,9 @@
-export * from "./building_highlight";
-export * from "./building_highlight_options";
-export * from "./building_information";
-export * from "./building_dimensions";
-export * from "./building_contour";
+export { buildingHighlight, BuildingHighlight } from "./building_highlight";
+export {
+  buildingHighlightOptions,
+  BuildingHighlightOptions,
+  BuildingHighlightSelectionType,
+} from "./building_highlight_options";
+export { BuildingInformation } from "./building_information";
+export { BuildingDimensions } from "./building_dimensions";
+export { BuildingContour } from "./building_contour";

--- a/src/public/buildings/buildings.js
+++ b/src/public/buildings/buildings.js
@@ -1,16 +1,5 @@
-var _buildingHighlight = require("./building_highlight");
-var _buildingHighlightOptions = require("./building_highlight_options");
-var _buildingInformation = require("./building_information");
-var _buildingDimensions = require("./building_dimensions");
-var _buildingContour = require("./building_contour");
-
-module.exports = {
-    BuildingHighlight: _buildingHighlight.BuildingHighlight,
-    BuildingHighlightOptions: _buildingHighlightOptions.BuildingHighlightOptions,
-    buildingHighlight: _buildingHighlight.buildingHighlight,
-    buildingHighlightOptions: _buildingHighlightOptions.buildingHighlightOptions,
-    BuildingHighlightSelectionType: _buildingHighlightOptions.BuildingHighlightSelectionType,
-    BuildingInformation: _buildingInformation,
-    BuildingDimensions: _buildingDimensions,
-    BuildingContour: _buildingContour
-};
+export * from "./building_highlight";
+export * from "./building_highlight_options";
+export * from "./building_information";
+export * from "./building_dimensions";
+export * from "./building_contour";

--- a/src/public/circle.js
+++ b/src/public/circle.js
@@ -70,6 +70,4 @@ export const Circle = L.Circle.extend({
     }
 });
 
-export const circle = function (latlng, options, legacyOptions) {
-	return new Circle(latlng, options, legacyOptions);
-};
+export const circle = (latlng, options, legacyOptions) => new Circle(latlng, options, legacyOptions);

--- a/src/public/circle.js
+++ b/src/public/circle.js
@@ -1,9 +1,9 @@
-var elevationMode = require("../private/elevation_mode.js");
+import { ElevationModeType, isValidElevationMode } from "../private/elevation_mode.js";
 
-var Circle = L.Circle.extend({
+export const Circle = L.Circle.extend({
     options: {
         elevation: 0,
-        elevationMode: elevationMode.ElevationModeType.HEIGHT_ABOVE_GROUND
+        elevationMode: ElevationModeType.HEIGHT_ABOVE_GROUND
     },
 
     _project: function () {
@@ -54,7 +54,7 @@ var Circle = L.Circle.extend({
     },
 
     setElevationMode: function(mode) {
-        if (elevationMode.isValidElevationMode(mode)) {
+        if (isValidElevationMode(mode)) {
             this.options.elevationMode = mode;
 
             if (this._map !== null) {
@@ -70,11 +70,6 @@ var Circle = L.Circle.extend({
     }
 });
 
-var circle = function (latlng, options, legacyOptions) {
+export const circle = function (latlng, options, legacyOptions) {
 	return new Circle(latlng, options, legacyOptions);
-};
-
-module.exports = {
-    Circle: Circle,
-    circle: circle
 };

--- a/src/public/eegeo_leaflet_map.js
+++ b/src/public/eegeo_leaflet_map.js
@@ -1,5 +1,5 @@
-var popups = require("../public/popup.js");
-var indoorOptions = require("../private/indoor_map_layer_options.js");
+import { Popup } from "../public/popup.js";
+import { hasIndoorMap, matchesIndoorMap } from "../private/indoor_map_layer_options.js";
 
 var undefinedPoint = L.point(-100, -100);
 var undefinedLatLng = L.latLng(0, 0);
@@ -401,7 +401,7 @@ var EegeoLeafletMap = L.Map.extend({
     openPopup: function(popup, latLng, options) {
         if (!(popup instanceof L.Popup)) {
             var content = popup;
-            popup = new popups.Popup(options)
+            popup = new Popup(options)
                 .setLatLng(latLng)
                 .setContent(content);
         }
@@ -581,7 +581,7 @@ var EegeoLeafletMap = L.Map.extend({
 
     _isVisibleForCurrentMapState: function(layer) {
         var currentMapStateIsOutdoors = !this.indoors.isIndoors();
-        var layerIsOutdoors = !indoorOptions.hasIndoorMap(layer);
+        var layerIsOutdoors = !hasIndoorMap(layer);
 
 		if (layer.options.displayOption === "currentMap")
 			return true;
@@ -596,7 +596,7 @@ var EegeoLeafletMap = L.Map.extend({
             return false;
         }
 
-        return indoorOptions.matchesIndoorMap(
+        return matchesIndoorMap(
             this.indoors.getActiveIndoorMap().getIndoorMapId(),
             this.indoors.getFloor()._getFloorId(),
             this.indoors.getFloor().getFloorIndex(),
@@ -609,4 +609,4 @@ var EegeoLeafletMap = L.Map.extend({
 
 });
 
-module.exports = EegeoLeafletMap;
+export default EegeoLeafletMap;

--- a/src/public/eegeo_leaflet_map.js
+++ b/src/public/eegeo_leaflet_map.js
@@ -4,7 +4,7 @@ import { hasIndoorMap, matchesIndoorMap } from "../private/indoor_map_layer_opti
 var undefinedPoint = L.point(-100, -100);
 var undefinedLatLng = L.latLng(0, 0);
 
-var getCenterOfLayer = function(layer) {
+const getCenterOfLayer = (layer) => {
     if ("getLatLng" in layer) {
         return layer.getLatLng();
     }
@@ -14,7 +14,7 @@ var getCenterOfLayer = function(layer) {
     return null;
 };
 
-var convertLatLngToVector = function(latLng) {
+const convertLatLngToVector = (latLng) => {
     var lat = latLng.lat * Math.PI / 180;
     var lng = latLng.lng * Math.PI / 180;
 
@@ -32,13 +32,13 @@ var convertLatLngToVector = function(latLng) {
 
 // Prevent Renderer from panning and scaling the overlay layer
 L.Renderer.include({
-    _updateTransform: function() { }
+    _updateTransform: () => { }
 });
 
 
-var EegeoLeafletMap = L.Map.extend({
+export const EegeoLeafletMap = L.Map.extend({
 
-    initialize: function(
+    initialize: function (
             browserWindow,
             id,
             options,
@@ -196,14 +196,14 @@ var EegeoLeafletMap = L.Map.extend({
 
     _removeAllLayers: function() {
         var layerIds = Object.keys(this._layersOnMap);
-        var _this = this;
-        layerIds.forEach(function(id) {
-            var layer = _this._layersOnMap[id];
-            if (layer === undefined) {
-                return;
-            }
-            _this.removeLayer(layer);
-        });
+        
+        layerIds.forEach((id) => {
+                var layer = this._layersOnMap[id];
+                if (layer === undefined) {
+                    return;
+                }
+                this.removeLayer(layer);
+            });
     },
 
     onInitialized: function(emscriptenApi) {
@@ -416,14 +416,14 @@ var EegeoLeafletMap = L.Map.extend({
     _onDraw: function() {
         this._updateLayerVisibility();
 
-        this.eachLayer(function (layer) {
-            if (layer.update) {
-                layer.update();
-            }
-            else if (layer.redraw) {
-                layer.redraw();
-            }
-        });
+        this.eachLayer((layer) => {
+                if (layer.update) {
+                    layer.update();
+                }
+                else if (layer.redraw) {
+                    layer.redraw();
+                }
+            });
         this.fire("draw");
     },
 
@@ -545,7 +545,7 @@ var EegeoLeafletMap = L.Map.extend({
         var maxAngle = this._getAngleFromCameraToHorizon();
 
         var _this = this;
-        layerIds.forEach(function(id) {
+        layerIds.forEach((id) => {
             var layer = _this._layersOnMap[id];
 
             // we're checking for null, as there's a few potentially confusing interactions that can happen.
@@ -553,7 +553,7 @@ var EegeoLeafletMap = L.Map.extend({
             // have layerIds = [ 23, 75 ] and both of these ids exist in the _layersOnMap dictionary. However, a side-effect of removing
             // a marker is that any associated popup will be removed. We're spinning over the layerIds that we copied _before_
             // removing anything, so we now have a stale id (75) that no longer exists in _layersOnMap, and we can skip it.
-            if(layer === undefined) {
+            if (layer === undefined) {
                 return;
             }
 
@@ -575,7 +575,6 @@ var EegeoLeafletMap = L.Map.extend({
             else if (hasLayer && (latLngBehindEarth || !indoorMapDisplayFilter)) {
                 L.Map.prototype.removeLayer.call(_this, layer);
             }
-
         });
     },
 

--- a/src/public/entity_set_prop.js
+++ b/src/public/entity_set_prop.js
@@ -1,4 +1,4 @@
-export const IndoorMapEntitySetProp = function(
+export function IndoorMapEntitySetProp (
         indoorMapId,
         floorId,
         name,
@@ -18,54 +18,41 @@ export const IndoorMapEntitySetProp = function(
     var _elevationMode = elevationMode;
     var _headingDegrees = headingDegrees;
     
-    this.getIndoorMapId = function() {
-        return _indoorMapId;
-    };
+    this.getIndoorMapId = () => _indoorMapId;
     
-    this.getIndoorMapFloorId = function() {
-        return _floorId;
-    };
+    this.getIndoorMapFloorId = () => _floorId;
     
-    this.getName = function() {
-        return _name;
-    };
+    this.getName = () => _name;
     
-    this.getGeometryId = function() {
-        return _geometryId;
-    };
+    this.getGeometryId = () => _geometryId;
     
-    this.getLocation = function() {
-        return _location;
-    };
+    this.getLocation = () => _location;
     
-    this.getElevation = function() {
-        return _elevation;
-    };
+    this.getElevation = () => _elevation;
     
-    this.getElevationMode = function() {
-        return _elevationMode;
-    };
+    this.getElevationMode = () => _elevationMode;
     
-    this.getHeadingDegrees = function() {
-        return _headingDegrees;
-    };
-};
+    this.getHeadingDegrees = () => _headingDegrees;
+}
 
-export const indoorMapEntitySetProp = function(indoorMapId,
-                                      floorId,
-                                      name,
-                                      geometryId,
-                                      location,
-                                      elevation,
-                                      elevationMode,
-                                      headingDegrees) {
+export const indoorMapEntitySetProp = (
+  indoorMapId,
+  floorId,
+  name,
+  geometryId,
+  location,
+  elevation,
+  elevationMode,
+  headingDegrees
+) =>
+  new IndoorMapEntitySetProp(
+    indoorMapId,
+    floorId,
+    name,
+    geometryId,
+    location,
+    elevation,
+    elevationMode,
+    headingDegrees
+  );
 
-    return new IndoorMapEntitySetProp(indoorMapId,
-                                      floorId,
-                                      name,
-                                      geometryId,
-                                      location,
-                                      elevation,
-                                      elevationMode,
-                                      headingDegrees);
-};

--- a/src/public/entity_set_prop.js
+++ b/src/public/entity_set_prop.js
@@ -1,4 +1,4 @@
-var IndoorMapEntitySetProp = function(
+export const IndoorMapEntitySetProp = function(
         indoorMapId,
         floorId,
         name,
@@ -51,7 +51,7 @@ var IndoorMapEntitySetProp = function(
     };
 };
 
-var indoorMapEntitySetProp = function(indoorMapId,
+export const indoorMapEntitySetProp = function(indoorMapId,
                                       floorId,
                                       name,
                                       geometryId,
@@ -68,9 +68,4 @@ var indoorMapEntitySetProp = function(indoorMapId,
                                       elevation,
                                       elevationMode,
                                       headingDegrees);
-};
-
-module.exports = {
-    IndoorMapEntitySetProp: IndoorMapEntitySetProp,
-    indoorMapEntitySetProp: indoorMapEntitySetProp
 };

--- a/src/public/heatmap.js
+++ b/src/public/heatmap.js
@@ -61,28 +61,28 @@ export const Heatmap = (L.Layer ? L.Layer : L.Class).extend({
         var weightedCoords = [];
         var dataCoordProperty = this.options.dataCoordProperty;
         var dataWeightProperty = this.options.dataWeightProperty;
-        pointData.forEach(function (pointDatum) {
-            var weight = 1.0;
-            var latLng = [];
-            if (dataCoordProperty in pointDatum) {
-                latLng = L.latLng(pointDatum[dataCoordProperty]);
+        pointData.forEach((pointDatum) => {
+                var weight = 1.0;
+                var latLng = [];
+                if (dataCoordProperty in pointDatum) {
+                    latLng = L.latLng(pointDatum[dataCoordProperty]);
 
-                if (dataWeightProperty in pointDatum) {
-                    weight = pointDatum[dataWeightProperty];
+                    if (dataWeightProperty in pointDatum) {
+                        weight = pointDatum[dataWeightProperty];
+                    }
                 }
-            }
-            else {
-                latLng = L.latLng(pointDatum[0], pointDatum[1]);
-                if (pointDatum.length > 2) {
-                    weight = pointDatum[2];
+                else {
+                    latLng = L.latLng(pointDatum[0], pointDatum[1]);
+                    if (pointDatum.length > 2) {
+                        weight = pointDatum[2];
+                    }
                 }
-            }
 
-            weightedCoords.push({
-                latLng: latLng,
-                weight: weight
+                weightedCoords.push({
+                    latLng: latLng,
+                    weight: weight
+                });
             });
-        });
         return weightedCoords;
     },
 
@@ -175,7 +175,7 @@ export const Heatmap = (L.Layer ? L.Layer : L.Class).extend({
             densityStops.push(this._loadDensityParams(densityStopsArray));
         }
         else if (arrayDepth <= 2) {
-            densityStopsArray.forEach(function (densityStopsSet) {
+            densityStopsArray.forEach((densityStopsSet) => {
                 densityStops.push(this._loadDensityParams(densityStopsSet));
             }, this);
         }
@@ -596,7 +596,5 @@ export const Heatmap = (L.Layer ? L.Layer : L.Class).extend({
     }
 });
 
-export const heatmap = function (pointData, heatmapOptions) {
-    return new Heatmap(pointData, heatmapOptions || {});
-};
+export const heatmap = (pointData, heatmapOptions) => new Heatmap(pointData, heatmapOptions || {});
 

--- a/src/public/heatmap.js
+++ b/src/public/heatmap.js
@@ -1,13 +1,13 @@
-var elevationMode = require("../private/elevation_mode.js");
+import { ElevationModeType, isValidElevationMode } from "../private/elevation_mode.js";
 
-var HeatmapOcclusionMapFeature = {
+export const HeatmapOcclusionMapFeature = {
     GROUND: "ground",
     BUILDINGS: "buildings",
     TREES: "trees",
     TRANSPORT: "transport"
 };
 
-var Heatmap = (L.Layer ? L.Layer : L.Class).extend({
+export const Heatmap = (L.Layer ? L.Layer : L.Class).extend({
 
     constants: {
         RESOLUTION_PIXELS_MIN: 64.0,
@@ -18,7 +18,7 @@ var Heatmap = (L.Layer ? L.Layer : L.Class).extend({
         dataCoordProperty: "latLng",
         dataWeightProperty: "weight",
         elevation: 0.0,
-        elevationMode: elevationMode.ElevationModeType.HEIGHT_ABOVE_GROUND,
+        elevationMode: ElevationModeType.HEIGHT_ABOVE_GROUND,
         indoorMapId: "",
         indoorMapFloorId: 0,
         polygonPoints: [],
@@ -364,7 +364,7 @@ var Heatmap = (L.Layer ? L.Layer : L.Class).extend({
     },
 
     setElevationMode: function (mode) {
-        if (!elevationMode.isValidElevationMode(mode)) {
+        if (!isValidElevationMode(mode)) {
             throw new Error("Heatmap elevationMode must be valid");
         }
         this.options.elevationMode = mode;
@@ -596,12 +596,7 @@ var Heatmap = (L.Layer ? L.Layer : L.Class).extend({
     }
 });
 
-var heatmap = function (pointData, heatmapOptions) {
+export const heatmap = function (pointData, heatmapOptions) {
     return new Heatmap(pointData, heatmapOptions || {});
 };
 
-module.exports = {
-    Heatmap: Heatmap,
-    heatmap: heatmap,
-    HeatmapOcclusionMapFeature: HeatmapOcclusionMapFeature
-};

--- a/src/public/indoorMapEntities/indoorMapEntities.js
+++ b/src/public/indoorMapEntities/indoorMapEntities.js
@@ -1,2 +1,5 @@
-export * from "./indoor_map_entity_information";
-export * from "./indoor_map_entity";
+export {
+  indoorMapEntityInformation,
+  IndoorMapEntityInformation,
+} from "./indoor_map_entity_information";
+export { IndoorMapEntity } from "./indoor_map_entity";

--- a/src/public/indoorMapEntities/indoorMapEntities.js
+++ b/src/public/indoorMapEntities/indoorMapEntities.js
@@ -1,8 +1,2 @@
-var _indoorMapEntityInformation = require("./indoor_map_entity_information");
-var _indoorMapEntity = require("./indoor_map_entity");
-
-module.exports = {
-    IndoorMapEntity: _indoorMapEntity,
-    IndoorMapEntityInformation: _indoorMapEntityInformation.IndoorMapEntityInformation,
-    indoorMapEntityInformation: _indoorMapEntityInformation.indoorMapEntityInformation
-};
+export * from "./indoor_map_entity_information";
+export * from "./indoor_map_entity";

--- a/src/public/indoorMapEntities/indoor_map_entity.js
+++ b/src/public/indoorMapEntities/indoor_map_entity.js
@@ -1,23 +1,14 @@
-export const IndoorMapEntity = function(indoorMapEntityId, indoorMapFloorId, position, outline) {
+export function IndoorMapEntity (indoorMapEntityId, indoorMapFloorId, position, outline) {
     var _indoorMapEntityId = indoorMapEntityId;
     var _indoorMapFloorId = indoorMapFloorId;
     var _position = position;
     var _outline = outline;
 
-    this.getIndoorMapEntityId = function() {
-        return _indoorMapEntityId;
-    };
+    this.getIndoorMapEntityId = () => _indoorMapEntityId;
 
-    this.getIndoorMapFloorId = function() {
-        return _indoorMapFloorId;
-    };
+    this.getIndoorMapFloorId = () => _indoorMapFloorId;
 
-    this.getPosition = function() {
-        return _position;
-    };
+    this.getPosition = () => _position;
 
-    this.getOutline = function(){
-        return _outline;
-    };
-
-};
+    this.getOutline = () => _outline;
+}

--- a/src/public/indoorMapEntities/indoor_map_entity.js
+++ b/src/public/indoorMapEntities/indoor_map_entity.js
@@ -1,4 +1,4 @@
-var IndoorMapEntity = function(indoorMapEntityId, indoorMapFloorId, position, outline) {
+export const IndoorMapEntity = function(indoorMapEntityId, indoorMapFloorId, position, outline) {
     var _indoorMapEntityId = indoorMapEntityId;
     var _indoorMapFloorId = indoorMapFloorId;
     var _position = position;
@@ -21,5 +21,3 @@ var IndoorMapEntity = function(indoorMapEntityId, indoorMapFloorId, position, ou
     };
 
 };
-
-module.exports = IndoorMapEntity;

--- a/src/public/indoorMapEntities/indoor_map_entity_information.js
+++ b/src/public/indoorMapEntities/indoor_map_entity_information.js
@@ -4,7 +4,7 @@ const IndoorMapEntityInformationLoadStateType = {
     COMPLETE: "Complete"
 };
 
-export const IndoorMapEntityInformation = function(indoorMapId) {
+export function IndoorMapEntityInformation (indoorMapId) {
     
     var _nativeId = null;
     var _map = null;
@@ -12,36 +12,26 @@ export const IndoorMapEntityInformation = function(indoorMapId) {
     var _indoorMapEntities = [];
     var _loadState = IndoorMapEntityInformationLoadStateType.NONE;
 
-    this.getIndoorMapId = function() {
-        return _indoorMapId;
-    };
+    this.getIndoorMapId = () => _indoorMapId;
     
-    this.getIndoorMapEntities = function() {
-        return _indoorMapEntities;
-    };
+    this.getIndoorMapEntities = () => _indoorMapEntities;
 
-    this.getLoadState = function() {
-        return _loadState;
-    };
+    this.getLoadState = () => _loadState;
 
     /**
      * Returns the auto-incrementing unique id of this IndoorMapEntityInformation object.
      * @returns {number}
      */
-    this.getId = function() {
-        return _nativeId;
-    };
+    this.getId = () => _nativeId;
 
     /**
      * Returns the auto-incrementing unique id of this IndoorMapEntityInformation object.
      * @deprecated use {@link IndoorMapEntityInformation.getId}
      * @returns {number}
      */
-    this.getNativeId = function() {
-        return _nativeId;
-    };
+    this.getNativeId = () => _nativeId;
 
-    this.addTo = function(map) {
+    this.addTo = (map) => {
         if (_map !== null) {
             this.remove();
         }
@@ -50,7 +40,7 @@ export const IndoorMapEntityInformation = function(indoorMapId) {
         return this;
     };
 
-    this.remove = function() {
+    this.remove = () => {
         if (_map !== null) {
             _map.indoorMapEntities._getImpl().removeIndoorMapEntityInformation(this);
             _map = null;
@@ -58,11 +48,11 @@ export const IndoorMapEntityInformation = function(indoorMapId) {
         return this;
     };
 
-    this._setNativeHandle = function(nativeId) {
+    this._setNativeHandle = (nativeId) => {
         _nativeId = nativeId;
     };
 
-    this._setData = function(data) {
+    this._setData = (data) => {
         _indoorMapEntities = data.IndoorMapEntities;
 
         switch(data.LoadState)
@@ -78,8 +68,6 @@ export const IndoorMapEntityInformation = function(indoorMapId) {
                 break;
         }
     };
-};
+}
 
-export const indoorMapEntityInformation = function(indoorMapId) {
-    return new IndoorMapEntityInformation(indoorMapId);
-};
+export const indoorMapEntityInformation = (indoorMapId) => new IndoorMapEntityInformation(indoorMapId);

--- a/src/public/indoorMapEntities/indoor_map_entity_information.js
+++ b/src/public/indoorMapEntities/indoor_map_entity_information.js
@@ -1,10 +1,10 @@
-var IndoorMapEntityInformationLoadStateType = {
+const IndoorMapEntityInformationLoadStateType = {
     NONE: "None",
     PARTIAL: "Partial",
     COMPLETE: "Complete"
 };
 
-var IndoorMapEntityInformation = function(indoorMapId) {
+export const IndoorMapEntityInformation = function(indoorMapId) {
     
     var _nativeId = null;
     var _map = null;
@@ -80,11 +80,6 @@ var IndoorMapEntityInformation = function(indoorMapId) {
     };
 };
 
-var indoorMapEntityInformation = function(indoorMapId) {
+export const indoorMapEntityInformation = function(indoorMapId) {
     return new IndoorMapEntityInformation(indoorMapId);
-};
-
-module.exports = {
-    IndoorMapEntityInformation: IndoorMapEntityInformation,
-    indoorMapEntityInformation: indoorMapEntityInformation
 };

--- a/src/public/indoorMapFloorOutlines/indoorMapFloorOutlines.js
+++ b/src/public/indoorMapFloorOutlines/indoorMapFloorOutlines.js
@@ -1,10 +1,3 @@
-var _indoorMapFloorOutlineInformation = require("./indoor_map_floor_outline_information");
-var _indoorMapFloorOutlinePolygon = require("./indoor_map_floor_outline_polygon");
-var _indoorMapFloorOutlinePolygonRing = require("./indoor_map_floor_outline_polygon_ring");
-
-module.exports = {
-    IndoorMapFloorOutlinePolygon: _indoorMapFloorOutlinePolygon,
-    IndoorMapFloorOutlinePolygonRing: _indoorMapFloorOutlinePolygonRing,
-    IndoorMapFloorOutlineInformation: _indoorMapFloorOutlineInformation.IndoorMapFloorOutlineInformation,
-    indoorMapFloorOutlineInformation: _indoorMapFloorOutlineInformation.indoorMapFloorOutlineInformation
-};
+export * from "./indoor_map_floor_outline_information";
+export * from "./indoor_map_floor_outline_polygon";
+export * from "./indoor_map_floor_outline_polygon_ring";

--- a/src/public/indoorMapFloorOutlines/indoorMapFloorOutlines.js
+++ b/src/public/indoorMapFloorOutlines/indoorMapFloorOutlines.js
@@ -1,3 +1,6 @@
-export * from "./indoor_map_floor_outline_information";
-export * from "./indoor_map_floor_outline_polygon";
-export * from "./indoor_map_floor_outline_polygon_ring";
+export {
+  indoorMapFloorOutlineInformation,
+  IndoorMapFloorOutlineInformation,
+} from "./indoor_map_floor_outline_information";
+export { IndoorMapFloorOutlinePolygon } from "./indoor_map_floor_outline_polygon";
+export { IndoorMapFloorOutlinePolygonRing } from "./indoor_map_floor_outline_polygon_ring";

--- a/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_information.js
+++ b/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_information.js
@@ -1,5 +1,4 @@
-export const IndoorMapFloorOutlineInformation = function(indoorMapId, indoorMapFloorId) {
-
+export function IndoorMapFloorOutlineInformation (indoorMapId, indoorMapFloorId) {
   var _nativeId = null;
   var _map = null;
   var _indoorMapId = indoorMapId;
@@ -7,53 +6,42 @@ export const IndoorMapFloorOutlineInformation = function(indoorMapId, indoorMapF
   var _outlinePolygons = [];
   var _isLoaded = false;
 
-  this.getIndoorMapId = function() {
-      return _indoorMapId;
-  };
+  this.getIndoorMapId = () => _indoorMapId;
 
-  this.getIndoorMapFloorId = function() {
-      return _indoorMapFloorId;
-  };
+  this.getIndoorMapFloorId = () => _indoorMapFloorId;
   
-  this.getIndoorMapFloorOutlinePolygons = function() {
-      return _outlinePolygons;
+  this.getIndoorMapFloorOutlinePolygons = () => _outlinePolygons;
+
+  this.getIsLoaded = () => _isLoaded;
+
+  this.getId = () => _nativeId;
+
+  this.addTo = (map) => {
+    if (_map !== null) {
+        this.remove();
+    }
+    _map = map;
+    _map.indoorMapFloorOutlines._getImpl().addIndoorMapFloorOutlineInformation(this);
+    return this;
   };
 
-  this.getIsLoaded = function() {
-      return _isLoaded;
+  this.remove = () => {
+    if (_map !== null) {
+        _map.indoorMapFloorOutlines._getImpl().removeIndoorMapFloorOutlineInformation(this);
+        _map = null;
+    }
+    return this;
   };
 
-  this.getId = function() {
-      return _nativeId;
+  this._setNativeHandle = (nativeId) => {
+    _nativeId = nativeId;
   };
 
-  this.addTo = function(map) {
-      if (_map !== null) {
-          this.remove();
-      }
-      _map = map;
-      _map.indoorMapFloorOutlines._getImpl().addIndoorMapFloorOutlineInformation(this);
-      return this;
+  this._setData = (data) => {
+    _outlinePolygons = data;
+    _isLoaded = true;
   };
+}
 
-  this.remove = function() {
-      if (_map !== null) {
-          _map.indoorMapFloorOutlines._getImpl().removeIndoorMapFloorOutlineInformation(this);
-          _map = null;
-      }
-      return this;
-  };
-
-  this._setNativeHandle = function(nativeId) {
-      _nativeId = nativeId;
-  };
-
-  this._setData = function(data) {
-      _outlinePolygons = data;
-      _isLoaded = true;
-  };
-};
-
-export const indoorMapFloorOutlineInformation = function(indoorMapId, indoorMapFloorId) {
-  return new IndoorMapFloorOutlineInformation(indoorMapId, indoorMapFloorId);
-};
+export const indoorMapFloorOutlineInformation = (indoorMapId, indoorMapFloorId) =>
+    new IndoorMapFloorOutlineInformation(indoorMapId, indoorMapFloorId);

--- a/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_information.js
+++ b/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_information.js
@@ -1,4 +1,4 @@
-var IndoorMapFloorOutlineInformation = function(indoorMapId, indoorMapFloorId) {
+export const IndoorMapFloorOutlineInformation = function(indoorMapId, indoorMapFloorId) {
 
   var _nativeId = null;
   var _map = null;
@@ -54,11 +54,6 @@ var IndoorMapFloorOutlineInformation = function(indoorMapId, indoorMapFloorId) {
   };
 };
 
-var indoorMapFloorOutlineInformation = function(indoorMapId, indoorMapFloorId) {
+export const indoorMapFloorOutlineInformation = function(indoorMapId, indoorMapFloorId) {
   return new IndoorMapFloorOutlineInformation(indoorMapId, indoorMapFloorId);
-};
-
-module.exports = {
-  IndoorMapFloorOutlineInformation: IndoorMapFloorOutlineInformation,
-  indoorMapFloorOutlineInformation: indoorMapFloorOutlineInformation
 };

--- a/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon.js
+++ b/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon.js
@@ -1,14 +1,10 @@
-export const IndoorMapFloorOutlinePolygon = function (outerRing, innerRings) {
+export function IndoorMapFloorOutlinePolygon(outerRing, innerRings) {
   var _outerRing = outerRing;
   var _innerRings = innerRings;
 
-  this.getOuterRing = function () {
-    return _outerRing;
-  };
+  this.getOuterRing = () => _outerRing;
 
-  this.getInnerRings = function () {
-    return _innerRings;
-  };
-};
+  this.getInnerRings = () => _innerRings;
+}
 
 export default IndoorMapFloorOutlinePolygon;

--- a/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon.js
+++ b/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon.js
@@ -1,15 +1,14 @@
-var IndoorMapFloorOutlinePolygon = function(outerRing, innerRings) {
+export const IndoorMapFloorOutlinePolygon = function (outerRing, innerRings) {
   var _outerRing = outerRing;
   var _innerRings = innerRings;
 
-  this.getOuterRing = function() {
-      return _outerRing;
+  this.getOuterRing = function () {
+    return _outerRing;
   };
 
-  this.getInnerRings = function() {
-      return _innerRings;
+  this.getInnerRings = function () {
+    return _innerRings;
   };
-
 };
 
-module.exports = IndoorMapFloorOutlinePolygon;
+export default IndoorMapFloorOutlinePolygon;

--- a/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring.js
+++ b/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring.js
@@ -1,10 +1,9 @@
-var IndoorMapFloorOutlinePolygonRing = function(latLngPoints) {
+export const IndoorMapFloorOutlinePolygonRing = function (latLngPoints) {
   var _latLngPoints = latLngPoints;
 
-  this.getLatLngPoints = function() {
-      return _latLngPoints;
+  this.getLatLngPoints = function () {
+    return _latLngPoints;
   };
-
 };
 
-module.exports = IndoorMapFloorOutlinePolygonRing;
+export default IndoorMapFloorOutlinePolygonRing;

--- a/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring.js
+++ b/src/public/indoorMapFloorOutlines/indoor_map_floor_outline_polygon_ring.js
@@ -1,9 +1,7 @@
-export const IndoorMapFloorOutlinePolygonRing = function (latLngPoints) {
+export function IndoorMapFloorOutlinePolygonRing(latLngPoints) {
   var _latLngPoints = latLngPoints;
 
-  this.getLatLngPoints = function () {
-    return _latLngPoints;
-  };
-};
+  this.getLatLngPoints = () => _latLngPoints;
+}
 
 export default IndoorMapFloorOutlinePolygonRing;

--- a/src/public/indoors/indoor_map.js
+++ b/src/public/indoors/indoor_map.js
@@ -1,5 +1,4 @@
-export const IndoorMap = function(indoorMapId, indoorMapName, indoorMapSourceVendor, floorCount, floors, searchTags, exitFunc) {
-
+export function IndoorMap(indoorMapId, indoorMapName, indoorMapSourceVendor, floorCount, floors, searchTags, exitFunc) {
 	var _indoorMapId = indoorMapId;
 	var _indoorMapName = indoorMapName;
   var _indoorMapSourceVendor = indoorMapSourceVendor;
@@ -9,29 +8,17 @@ export const IndoorMap = function(indoorMapId, indoorMapName, indoorMapSourceVen
 
 	this.exit = exitFunc;
 
-	this.getIndoorMapId = function() {
-		return _indoorMapId;
-	};
+	this.getIndoorMapId = () => _indoorMapId;
 
-	this.getIndoorMapName = function() {
-		return _indoorMapName;
-	};
+	this.getIndoorMapName = () => _indoorMapName;
 
-  this.getIndoorMapSourceVendor = function() {
-    return _indoorMapSourceVendor;
-  };  
+  this.getIndoorMapSourceVendor = () => _indoorMapSourceVendor;  
 
-  this.getFloorCount = function() {
-      return _floorCount;
-  };
+  this.getFloorCount = () => _floorCount;
 
-  this.getFloors = function() {
-      return _floors;
-  };
+  this.getFloors = () => _floors;
 
-	this.getSearchTags = function() {
-		return _searchTags;
-	};
-};
+	this.getSearchTags = () => _searchTags;
+}
 
 export default IndoorMap;

--- a/src/public/indoors/indoor_map.js
+++ b/src/public/indoors/indoor_map.js
@@ -1,4 +1,4 @@
-var IndoorMap = function(indoorMapId, indoorMapName, indoorMapSourceVendor, floorCount, floors, searchTags, exitFunc) {
+export const IndoorMap = function(indoorMapId, indoorMapName, indoorMapSourceVendor, floorCount, floors, searchTags, exitFunc) {
 
 	var _indoorMapId = indoorMapId;
 	var _indoorMapName = indoorMapName;
@@ -34,4 +34,4 @@ var IndoorMap = function(indoorMapId, indoorMapName, indoorMapSourceVendor, floo
 	};
 };
 
-module.exports = IndoorMap;
+export default IndoorMap;

--- a/src/public/indoors/indoor_map_entrance.js
+++ b/src/public/indoors/indoor_map_entrance.js
@@ -1,4 +1,4 @@
-var IndoorMapEntrance = function(indoorMapId, indoorMapName, latLng) {
+export const IndoorMapEntrance = function(indoorMapId, indoorMapName, latLng) {
 
     var _indoorMapId = indoorMapId;
     var _indoorMapName = indoorMapName;
@@ -17,4 +17,4 @@ var IndoorMapEntrance = function(indoorMapId, indoorMapName, latLng) {
     };
 };
 
-module.exports = IndoorMapEntrance;
+export default IndoorMapEntrance;

--- a/src/public/indoors/indoor_map_entrance.js
+++ b/src/public/indoors/indoor_map_entrance.js
@@ -1,20 +1,13 @@
-export const IndoorMapEntrance = function(indoorMapId, indoorMapName, latLng) {
-
+export function IndoorMapEntrance (indoorMapId, indoorMapName, latLng) {
     var _indoorMapId = indoorMapId;
     var _indoorMapName = indoorMapName;
     var _latLng = latLng;
 
-    this.getIndoorMapId = function() {
-        return _indoorMapId;
-    };
+    this.getIndoorMapId = () => _indoorMapId;
 
-    this.getIndoorMapName = function() {
-        return _indoorMapName;
-    };
+    this.getIndoorMapName = () => _indoorMapName;
 
-    this.getLatLng = function() {
-        return _latLng;
-    };
-};
+    this.getLatLng = () => _latLng;
+}
 
 export default IndoorMapEntrance;

--- a/src/public/indoors/indoor_map_floor.js
+++ b/src/public/indoors/indoor_map_floor.js
@@ -1,4 +1,4 @@
-var IndoorMapFloor = function (floorId, floorIndex, floorName, floorShortName) {
+export const IndoorMapFloor = function (floorId, floorIndex, floorName, floorShortName) {
     var _floorId = floorId;
     var _floorIndex = floorIndex;
     var _floorName = floorName;
@@ -47,4 +47,4 @@ var IndoorMapFloor = function (floorId, floorIndex, floorName, floorShortName) {
     };
 };
 
-module.exports = IndoorMapFloor;
+export default IndoorMapFloor;

--- a/src/public/indoors/indoor_map_floor.js
+++ b/src/public/indoors/indoor_map_floor.js
@@ -1,4 +1,4 @@
-export const IndoorMapFloor = function (floorId, floorIndex, floorName, floorShortName) {
+export function IndoorMapFloor (floorId, floorIndex, floorName, floorShortName) {
     var _floorId = floorId;
     var _floorIndex = floorIndex;
     var _floorName = floorName;
@@ -10,9 +10,7 @@ export const IndoorMapFloor = function (floorId, floorIndex, floorName, floorSho
      * @deprecated use {@link IndoorMapFloor.getFloorShortName} instead.
      * @returns {string} the short name of the floor.
      */
-    this.getFloorId = function () {
-        return _floorShortName;
-    };
+    this.getFloorId = () => _floorShortName;
 
     /**
      * Note: this is for compatibility with the existing API. The actual id property in the submission json is not accessible through this API.
@@ -20,31 +18,21 @@ export const IndoorMapFloor = function (floorId, floorIndex, floorName, floorSho
      * @deprecated use {@link IndoorMapFloor.getFloorZOrder}
      * @returns {number} the z_order of the floor, as defined in the json submission.
      */
-    this._getFloorId = function () {
-        return _floorId;
-    };
+    this._getFloorId = () => _floorId;
 
     /**
      * @returns {number} the z_order of the floor, as defined in the json submission.
      */
-    this.getFloorZOrder = function () {
-        return _floorId;
-    };
+    this.getFloorZOrder = () => _floorId;
 
     /**
      * @returns {number} the index of this floor in the array.
      */
-    this.getFloorIndex = function () {
-        return _floorIndex;
-    };
+    this.getFloorIndex = () => _floorIndex;
 
-    this.getFloorName = function () {
-        return _floorName;
-    };
+    this.getFloorName = () => _floorName;
 
-    this.getFloorShortName = function () {
-        return _floorShortName;
-    };
-};
+    this.getFloorShortName = () => _floorShortName;
+}
 
 export default IndoorMapFloor;

--- a/src/public/indoors/indoors.js
+++ b/src/public/indoors/indoors.js
@@ -1,8 +1,3 @@
-var _indoorMap = require("./indoor_map");
-var _indoorMapEntrance = require("./indoor_map_entrance");
-var _indoorMapFloor = require("./indoor_map_floor");
-module.exports = {
-    IndoorMap: _indoorMap,
-    IndoorMapEntrance: _indoorMapEntrance,
-    IndoorMapFloor: _indoorMapFloor
-};
+export { IndoorMap } from "./indoor_map";
+export { IndoorMapEntrance } from "./indoor_map_entrance";
+export { IndoorMapFloor } from "./indoor_map_floor";

--- a/src/public/marker.js
+++ b/src/public/marker.js
@@ -3,7 +3,7 @@ import * as elevationMode from "../private/elevation_mode.js";
 import * as popups from "./popup";
 import { setPositionSmooth } from "../private/eegeo_dom_util";
 
-export var Marker = L.Marker.extend({
+export const Marker = L.Marker.extend({
     initialize: function(latlng, options) {
         L.Marker.prototype.initialize.call(this, latlng, options);
 
@@ -186,6 +186,4 @@ export var Marker = L.Marker.extend({
 
 });
 
-export var marker = function(latLng, options) {
-    return new Marker(latLng, options);
-};
+export var marker = (latLng, options) => new Marker(latLng, options);

--- a/src/public/marker.js
+++ b/src/public/marker.js
@@ -1,11 +1,9 @@
-var indoorOptions = require("../private/indoor_map_layer_options.js");
-var elevationMode = require("../private/elevation_mode.js");
+import * as indoorOptions from "../private/indoor_map_layer_options.js";
+import * as elevationMode from "../private/elevation_mode.js";
+import * as popups from "./popup";
+import { setPositionSmooth } from "../private/eegeo_dom_util";
 
-var popups = require("./popup");
-
-var EegeoDomUtil = require("../private/eegeo_dom_util");
-
-var Marker = L.Marker.extend({
+export var Marker = L.Marker.extend({
     initialize: function(latlng, options) {
         L.Marker.prototype.initialize.call(this, latlng, options);
 
@@ -114,7 +112,7 @@ var Marker = L.Marker.extend({
     },
 
     _setPos: function (pos) {
-        var setPosFunc = (L.Browser.gecko) ? EegeoDomUtil.setPositionSmooth : L.DomUtil.setPosition;
+        var setPosFunc = (L.Browser.gecko) ? setPositionSmooth : L.DomUtil.setPosition;
 
         setPosFunc(this._icon, pos);
 
@@ -188,11 +186,6 @@ var Marker = L.Marker.extend({
 
 });
 
-var marker = function(latLng, options) {
+export var marker = function(latLng, options) {
     return new Marker(latLng, options);
-};
-
-module.exports = {
-    Marker: Marker,
-    marker: marker
 };

--- a/src/public/polygon.js
+++ b/src/public/polygon.js
@@ -1,19 +1,19 @@
 import { latLng } from "leaflet";
 import { Vector4 } from "./space";
 
-export const Polygon = function(latLngs, config) {
+export function Polygon (latLngs, config) {
 	var _map = null;
 	var _outerRing = [];
 	var _holes = [];
   var _config = config || {};
 
-	function loadLatLngs(coords){
-    var points = [];
-		coords.forEach(function(coord) {
+	const loadLatLngs = (coords) => {
+		var points = [];
+		coords.forEach(function (coord) {
 			points.push(latLng(coord));
 		});
-    return points;
-	}
+		return points;
+	};
 
   var arrayDepth = 0;
   var testElement = latLngs;
@@ -43,38 +43,30 @@ export const Polygon = function(latLngs, config) {
 	var _colorNeedsChanged = true;
 
 
-	this.getColor = function() {
-		return _color;
-	};
+	this.getColor = () => _color;
 
-	this.setColor = function(color) {
+	this.setColor = (color) => {
 		_color = color;
 		_colorNeedsChanged = true;
     return this;
 	};
 
-	this.addHole = function(points) {
+	this.addHole = (points) => {
     _holes.push(loadLatLngs(points));
 		return this;
 	};
 
-	this.getHoles = function() {
-		return _holes;
-	};
+	this.getHoles = () => _holes;
 
-	this.getPoints = function() {
-		return _outerRing;
-	};
+	this.getPoints = () => _outerRing;
 
-	this._colorNeedsChanged = function() {
-		return _colorNeedsChanged;
-	};
+	this._colorNeedsChanged = () => _colorNeedsChanged;
 
-	this._onColorChanged = function() {
+	this._onColorChanged = () => {
 		_colorNeedsChanged = false;
 	};
 
-	this.addTo = function(map) {
+	this.addTo = (map) => {
 		if (_map !== null) {
 			this.remove();
 		}
@@ -83,7 +75,7 @@ export const Polygon = function(latLngs, config) {
 		return this;
 	};
 	
-	this.remove = function() {
+	this.remove = () => {
 		if (_map !== null) {
 			_map._polygonModule.removePolygon(this);
 			_map = null;
@@ -91,11 +83,7 @@ export const Polygon = function(latLngs, config) {
 		return this;
 	};
 
-  this._getConfig = function() {
-    return _config;
-  };
-};
+  this._getConfig = () => _config;
+}
 
-export const polygon = function(latlngs, config) {
-	return new Polygon(latlngs, config || {});
-};
+export const polygon = (latlngs, config) => new Polygon(latlngs, config || {});

--- a/src/public/polygon.js
+++ b/src/public/polygon.js
@@ -1,7 +1,7 @@
-var L = require("leaflet");
-var space = require("./space");
+import { latLng } from "leaflet";
+import { Vector4 } from "./space";
 
-var Polygon = function(latLngs, config) {
+export const Polygon = function(latLngs, config) {
 	var _map = null;
 	var _outerRing = [];
 	var _holes = [];
@@ -10,7 +10,7 @@ var Polygon = function(latLngs, config) {
 	function loadLatLngs(coords){
     var points = [];
 		coords.forEach(function(coord) {
-			points.push(L.latLng(coord));
+			points.push(latLng(coord));
 		});
     return points;
 	}
@@ -39,7 +39,7 @@ var Polygon = function(latLngs, config) {
     throw new Error("Incorrect array input format.");
   }
 
-	var _color = config["color"] || new space.Vector4(0, 0, 255, 128);
+	var _color = config["color"] || new Vector4(0, 0, 255, 128);
 	var _colorNeedsChanged = true;
 
 
@@ -96,11 +96,6 @@ var Polygon = function(latLngs, config) {
   };
 };
 
-var polygon = function(latlngs, config) {
+export const polygon = function(latlngs, config) {
 	return new Polygon(latlngs, config || {});
-};
-
-module.exports = {
-	Polygon: Polygon,
-	polygon: polygon
 };

--- a/src/public/polyline.js
+++ b/src/public/polyline.js
@@ -101,6 +101,4 @@ export const Polyline = _Polyline.extend({
     }
 });
 
-export const polyline = function(latlngs, polylineOptions) {
-    return new Polyline(latlngs, polylineOptions || {});
-};
+export const polyline = (latlngs, polylineOptions) => new Polyline(latlngs, polylineOptions || {});

--- a/src/public/polyline.js
+++ b/src/public/polyline.js
@@ -1,15 +1,15 @@
-var L = require("leaflet");
-var elevationMode = require("../private/elevation_mode.js");
+import { Polyline as _Polyline } from "leaflet";
+import { ElevationModeType, isValidElevationMode } from "../private/elevation_mode.js";
 
-var Polyline = L.Polyline.extend({
+export const Polyline = _Polyline.extend({
 
     initialize: function(latlngs, options) {
-        L.Polyline.prototype.initialize.call(this, latlngs, options);
+        _Polyline.prototype.initialize.call(this, latlngs, options);
     },
 
     options: {
         elevation: 0.0,
-        elevationMode: elevationMode.ElevationModeType.HEIGHT_ABOVE_GROUND,
+        elevationMode: ElevationModeType.HEIGHT_ABOVE_GROUND,
         indoorMapId: "",
         indoorMapFloorId: 0,
         weight: 3.0,
@@ -62,7 +62,7 @@ var Polyline = L.Polyline.extend({
     },
 
     setElevationMode: function(mode) {
-        if (elevationMode.isValidElevationMode(mode)) {
+        if (isValidElevationMode(mode)) {
             this.options.elevationMode = mode;
         }
         this._needsNativeUpdate = true;
@@ -74,7 +74,7 @@ var Polyline = L.Polyline.extend({
     },
 
     setStyle: function (style) {
-        L.Polyline.prototype.setStyle.call(this, style);
+        _Polyline.prototype.setStyle.call(this, style);
         this._needsNativeUpdate = true;
         return this;
     },
@@ -101,11 +101,6 @@ var Polyline = L.Polyline.extend({
     }
 });
 
-var polyline = function(latlngs, polylineOptions) {
+export const polyline = function(latlngs, polylineOptions) {
     return new Polyline(latlngs, polylineOptions || {});
-};
-
-module.exports = {
-    Polyline: Polyline,
-    polyline: polyline
 };

--- a/src/public/popup.js
+++ b/src/public/popup.js
@@ -1,4 +1,4 @@
-var Popup = L.Popup.extend({
+export const Popup = L.Popup.extend({
     options: {
         elevation: 0,
         closeWhenMovedOffscreen: false
@@ -121,11 +121,6 @@ var Popup = L.Popup.extend({
     }
 });
 
-var popup = function(options, source) {
+export const popup = function(options, source) {
     return new Popup(options, source);
-};
-
-module.exports = {
-    Popup: Popup,
-    popup: popup
 };

--- a/src/public/popup.js
+++ b/src/public/popup.js
@@ -121,6 +121,4 @@ export const Popup = L.Popup.extend({
     }
 });
 
-export const popup = function(options, source) {
-    return new Popup(options, source);
-};
+export const popup = (options, source) => new Popup(options, source);

--- a/src/public/precaching/precache_operation_result.js
+++ b/src/public/precaching/precache_operation_result.js
@@ -1,9 +1,7 @@
-export const PrecacheOperationResult = function(succeeded) {
-    var _succeeded = succeeded;
+export function PrecacheOperationResult(succeeded) {
+  var _succeeded = succeeded;
 
-    this.getSucceeded = function() {
-        return _succeeded;
-    };
-};
+  this.getSucceeded = () => _succeeded;
+}
 
 export default PrecacheOperationResult;

--- a/src/public/precaching/precache_operation_result.js
+++ b/src/public/precaching/precache_operation_result.js
@@ -1,4 +1,4 @@
-var PrecacheOperationResult = function(succeeded) {
+export const PrecacheOperationResult = function(succeeded) {
     var _succeeded = succeeded;
 
     this.getSucceeded = function() {
@@ -6,4 +6,4 @@ var PrecacheOperationResult = function(succeeded) {
     };
 };
 
-module.exports = PrecacheOperationResult;
+export default PrecacheOperationResult;

--- a/src/public/prop.js
+++ b/src/public/prop.js
@@ -1,6 +1,6 @@
-var elevationMode = require("../private/elevation_mode.js");
+import { ElevationModeType, isValidElevationMode } from "../private/elevation_mode.js";
 
-var Prop = function (name, geometryId, location, config) {
+export const Prop = function (name, geometryId, location, config) {
     var _map = null;
     var _name = name;
     var _geometryId = geometryId;
@@ -13,7 +13,7 @@ var Prop = function (name, geometryId, location, config) {
     var _headingDegreesNeedsChanged = false;
     var _elevation = config["elevation"] || 0.0;
     var _elevationNeedsChanged = false;
-    var _elevationMode = config["elevationMode"] || elevationMode.ElevationModeType.HEIGHT_ABOVE_GROUND;
+    var _elevationMode = config["elevationMode"] || ElevationModeType.HEIGHT_ABOVE_GROUND;
     var _elevationModeNeedsChanged = false;
     
     this.getLocation = function() {
@@ -59,7 +59,7 @@ var Prop = function (name, geometryId, location, config) {
     };
 
     this.setElevationMode = function (elevationModeString) {
-        if (elevationMode.isValidElevationMode(elevationModeString)) {
+        if (isValidElevationMode(elevationModeString)) {
             _elevationMode = elevationModeString;
             _elevationModeNeedsChanged = true;
         }
@@ -138,11 +138,6 @@ var Prop = function (name, geometryId, location, config) {
     };
 };
 
-var prop = function(name, geometryId, location, config) {
+export const prop = function(name, geometryId, location, config) {
     return new Prop(name, geometryId, location, config || {});
-};
-
-module.exports = {
-    Prop: Prop,
-    prop: prop
 };

--- a/src/public/prop.js
+++ b/src/public/prop.js
@@ -1,6 +1,6 @@
 import { ElevationModeType, isValidElevationMode } from "../private/elevation_mode.js";
 
-export const Prop = function (name, geometryId, location, config) {
+export function Prop (name, geometryId, location, config) {
     var _map = null;
     var _name = name;
     var _geometryId = geometryId;
@@ -16,49 +16,37 @@ export const Prop = function (name, geometryId, location, config) {
     var _elevationMode = config["elevationMode"] || ElevationModeType.HEIGHT_ABOVE_GROUND;
     var _elevationModeNeedsChanged = false;
     
-    this.getLocation = function() {
-        return _location;
-    };
+    this.getLocation = () => _location;
 
-    this.setLocation = function (location) {
+    this.setLocation = (location) => {
         _location = L.latLng(location);
         _locationNeedsChanged = true;
         return this;
     };
 
-    this.getIndoorMapId = function () {
-        return _indoorMapId;
-    };
+    this.getIndoorMapId = () => _indoorMapId;
 
-    this.getIndoorMapFloorId = function () {
-        return _indoorMapFloorId;
-    };
+    this.getIndoorMapFloorId = () => _indoorMapFloorId;
 
-    this.getHeadingDegrees = function () {
-        return _headingDegrees;
-    };
+    this.getHeadingDegrees = () => _headingDegrees;
 
-    this.setHeadingDegrees = function (headingDegrees) {
+    this.setHeadingDegrees = (headingDegrees) => {
         _headingDegrees = headingDegrees;
         _headingDegreesNeedsChanged = true;
         return this;
     };
 
-    this.getElevation = function () {
-        return _elevation;
-    };
+    this.getElevation = () => _elevation;
 
-    this.setElevation = function (elevation) {
+    this.setElevation = (elevation) => {
         _elevation = elevation;
         _elevationNeedsChanged = true;
         return this;
     };
 
-    this.getElevationMode = function () {
-        return _elevationMode;
-    };
+    this.getElevationMode = () => _elevationMode;
 
-    this.setElevationMode = function (elevationModeString) {
+    this.setElevationMode = (elevationModeString) => {
         if (isValidElevationMode(elevationModeString)) {
             _elevationMode = elevationModeString;
             _elevationModeNeedsChanged = true;
@@ -66,61 +54,47 @@ export const Prop = function (name, geometryId, location, config) {
         return this;
     };
 
-    this.getGeometryId = function () {
-        return _geometryId;
-    };
+    this.getGeometryId = () => _geometryId;
 
-    this.setGeometryId = function (geometryId) {
+    this.setGeometryId = (geometryId) => {
         _geometryId = geometryId;
         _geometryIdNeedsChanged = true;
         return this;
     };
 
-    this.getName = function () {
-        return _name;
-    };
+    this.getName = () => _name;
 
-    this._geometryIdNeedsChanged = function () {
-        return _geometryIdNeedsChanged;
-    };
+    this._geometryIdNeedsChanged = () => _geometryIdNeedsChanged;
 
-    this._onGeometryIdChanged = function () {
+    this._onGeometryIdChanged = () => {
         _geometryIdNeedsChanged = false;
     };
 
-    this._elevationNeedsChanged = function () {
-        return _elevationNeedsChanged;
-    };
+    this._elevationNeedsChanged = () => _elevationNeedsChanged;
 
-    this._onElevationChanged = function () {
+    this._onElevationChanged = () => {
         _elevationNeedsChanged = false;
     };
 
-    this._elevationModeNeedsChanged = function () {
-        return _elevationModeNeedsChanged;
-    };
+    this._elevationModeNeedsChanged = () => _elevationModeNeedsChanged;
 
-    this._onElevationModeChanged = function () {
+    this._onElevationModeChanged = () => {
         _elevationModeNeedsChanged = false;
     };
 
-    this._headingDegreesNeedsChanged = function () {
-        return _headingDegreesNeedsChanged;
-    };
+    this._headingDegreesNeedsChanged = () => _headingDegreesNeedsChanged;
 
-    this._onHeadingDegreesChanged = function () {
+    this._onHeadingDegreesChanged = () => {
         _headingDegreesNeedsChanged = false;
     };
 
-    this._locationNeedsChanged = function () {
-        return _locationNeedsChanged;
-    };
+    this._locationNeedsChanged = () => _locationNeedsChanged;
 
-    this._onLocationChanged = function () {
+    this._onLocationChanged = () => {
         _locationNeedsChanged = false;
     };
 
-    this.addTo = function(map) {
+    this.addTo = (map) => {
         if (_map !== null) {
             this.remove();
         }
@@ -129,15 +103,13 @@ export const Prop = function (name, geometryId, location, config) {
         return this;
     };
 	
-    this.remove = function() {
+    this.remove = () => {
         if (_map !== null) {
             _map.props.removeProp(this);
             _map = null;
         }
         return this;
     };
-};
+}
 
-export const prop = function(name, geometryId, location, config) {
-    return new Prop(name, geometryId, location, config || {});
-};
+export const prop = (name, geometryId, location, config) => new Prop(name, geometryId, location, config || {});

--- a/src/public/space.js
+++ b/src/public/space.js
@@ -10,7 +10,7 @@ export const Vector3 = function(x, y, z) {
         this.z = x.z || x[2] || 0.0;
     }
 
-    this.toPoint = function() {
+    this.toPoint = () => {
         return L.point(this.x, this.y);
     };
 };
@@ -61,31 +61,27 @@ var _altitudes = [
     5
 ];
 
-var _lerp = function (a,  b,  c) {
-    return a + c * (b - a);
-};
+var _lerp = (a, b, c) => a + c * (b - a);
 
-var _altitudeToZoom = function(altitude, comparisonFunc) {
-    var zoom = _altitudes.findIndex(function(zoomLevelDistance) {
+var _altitudeToZoom = (altitude, comparisonFunc) => {
+    var zoom = _altitudes.findIndex(function (zoomLevelDistance) {
         return comparisonFunc(altitude, zoomLevelDistance);
     });
     var maxZoom = _altitudes.length - 1;
     return (zoom === -1) ? maxZoom : zoom;
 };
 
-var _nearestZoomAbove = function(distance) {
-    var zoomAbove = _altitudeToZoom(distance, function(d, z) { return d > z; });
+var _nearestZoomAbove = (distance) => {
+    var zoomAbove = _altitudeToZoom(distance, function (d, z) { return d > z; });
     return Math.max(0, zoomAbove - 1);
 };
 
-var _nearestZoomBelow = function(distance) {
-    return _altitudeToZoom(distance, function(d, z) { return d >= z; });
-};
+var _nearestZoomBelow = (distance) => _altitudeToZoom(distance, (d, z) => d >= z);
 
-export const zoomToDistance = function(zoom) {
+export const zoomToDistance = (zoom) => {
     var zoomlevel = zoom;
-    if(zoomlevel < 0) {
-        zoomlevel =  0;
+    if (zoomlevel < 0) {
+        zoomlevel = 0;
     }
     else if (zoomlevel >= _altitudes.length) {
         zoomlevel = _altitudes.length - 1;
@@ -97,14 +93,12 @@ export const zoomToDistance = function(zoom) {
     return _lerp(_altitudes[nearestZoomBelow], _altitudes[nearestZoomAbove], valueBetweenNearestZoomLevels);
 };
 
-export const distanceToZoom = function(distance) {
+export const distanceToZoom = (distance) => {
     var smallestAltitude = _altitudes.length - 1;
-    if(distance < _altitudes[smallestAltitude])
-    {
+    if (distance < _altitudes[smallestAltitude]) {
         distance = _altitudes[smallestAltitude];
     }
-    if(distance > _altitudes[0])
-    {
+    if (distance > _altitudes[0]) {
         distance = _altitudes[0];
     }
     var nearestZoomAbove = _nearestZoomAbove(distance);

--- a/src/public/space.js
+++ b/src/public/space.js
@@ -1,4 +1,4 @@
-var Vector3 = function(x, y, z) {
+export const Vector3 = function(x, y, z) {
     if (typeof(x) === "number") {
         this.x = x;
         this.y = y;
@@ -15,7 +15,7 @@ var Vector3 = function(x, y, z) {
     };
 };
 
-var Vector4 = function(x, y, z, w) {
+export const Vector4 = function(x, y, z, w) {
     if (typeof(x) === "number") {
         this.x = x;
         this.y = y;
@@ -82,7 +82,7 @@ var _nearestZoomBelow = function(distance) {
     return _altitudeToZoom(distance, function(d, z) { return d >= z; });
 };
 
-var zoomToDistance = function(zoom) {
+export const zoomToDistance = function(zoom) {
     var zoomlevel = zoom;
     if(zoomlevel < 0) {
         zoomlevel =  0;
@@ -97,7 +97,7 @@ var zoomToDistance = function(zoom) {
     return _lerp(_altitudes[nearestZoomBelow], _altitudes[nearestZoomAbove], valueBetweenNearestZoomLevels);
 };
 
-var distanceToZoom = function(distance) {
+export const distanceToZoom = function(distance) {
     var smallestAltitude = _altitudes.length - 1;
     if(distance < _altitudes[smallestAltitude])
     {
@@ -114,12 +114,3 @@ var distanceToZoom = function(distance) {
 
     return (nearestZoomAbove === nearestZoomBelow) ? nearestZoomBelow : _lerp(nearestZoomBelow, nearestZoomAbove, distanceFromZoomLevelBelow / distanceBetweenNearestZoomLevels);
 };
-
-var space = {
-    Vector3: Vector3,
-    Vector4: Vector4,
-    zoomToDistance: zoomToDistance,
-    distanceToZoom: distanceToZoom
-};
-
-module.exports = space;

--- a/src/public/themes.js
+++ b/src/public/themes.js
@@ -1,29 +1,21 @@
-var season = {
+export const season = {
     Spring: "Spring",
     Summer: "Summer",
     Autumn: "Autumn",
     Winter: "Winter"
 };
 
-var time = {
+export const time = {
 	Dawn: "Dawn",
 	Day: "Day",
 	Dusk: "Dusk",
 	Night: "Night"
 };
 
-var weather = {
+export const weather = {
 	Clear: "Default",
 	Overcast: "Overcast",
 	Foggy: "Foggy",
 	Rainy: "Rainy",
 	Snowy: "Snowy"
 };
-
-var themes = {
-    season: season,
-    time: time,
-    weather: weather
-};
-
-module.exports = themes;

--- a/src/wrld.js
+++ b/src/wrld.js
@@ -1,18 +1,25 @@
-var L = require("leaflet");
-var EegeoMapController = require("./private/eegeo_map_controller");
-var EmscriptenApi = require("./private/emscripten_api/emscripten_api");
-var marker = require("./public/marker.js");
-var popup = require("./public/popup.js");
-var polygon = require("./public/polygon.js");
-var polyline = require("./public/polyline.js");
-var prop = require("./public/prop.js");
-var polygonShim = require("./private/polygon_shim.js");
-var polylineShim = require("./private/polyline_shim.js");
-var rectangleShim = require("./private/rectangle_shim.js");
-var circle = require("./public/circle.js");
-var heatmap = require("./public/heatmap.js");
+import L from "leaflet";
+import EegeoMapController from "./private/eegeo_map_controller";
+import EmscriptenApi from "./private/emscripten_api/emscripten_api";
+import * as marker from "./public/marker";
+import * as popup from "./public/popup.js";
+import * as polygon from "./public/polygon.js";
+import * as polyline from "./public/polyline.js";
+import * as prop from "./public/prop.js";
+import * as polygonShim from "./private/polygon_shim.js";
+import * as polylineShim from "./private/polyline_shim.js";
+import * as rectangleShim from "./private/rectangle_shim.js";
+import * as circle from "./public/circle.js";
+import * as heatmap from "./public/heatmap.js";
+// modules
+import * as indoors from "./public/indoors/indoors";
+import * as space from "./public/space";
+import * as themes from "./public/themes";
+import * as buildings from "./public/buildings/buildings";
+import * as indoorMapEntities from "./public/indoorMapEntities/indoorMapEntities";
+import * as indoorMapFloorOutlines from "./public/indoorMapFloorOutlines/indoorMapFloorOutlines";
 
-require("./private/polyfills.js");
+import "./private/polyfills.js";
 
 var _baseUrl = "https://cdn-webgl.wrld3d.com/eegeojs/public/latest/";
 var _appName = "eeGeoWebGL.jgz";
@@ -118,12 +125,12 @@ var Wrld = {
 	Heatmap: heatmap.Heatmap,
 	heatmap: heatmap.heatmap,
 
-	indoors: require("./public/indoors/indoors"),
-	space: require("./public/space"),
-	themes: require("./public/themes"),
-	buildings: require("./public/buildings/buildings"),
-	indoorMapEntities: require("./public/indoorMapEntities/indoorMapEntities"),
-	indoorMapFloorOutlines: require("./public/indoorMapFloorOutlines/indoorMapFloorOutlines"),
+	indoors: indoors,
+	space: space,
+	themes: themes,
+	buildings: buildings,
+	indoorMapEntities: indoorMapEntities,
+	indoorMapFloorOutlines: indoorMapFloorOutlines,
 
 	getMapById: function(mapId) {
 		return _mapObjects[mapId];
@@ -144,4 +151,4 @@ L.eeGeo = L.Wrld;
 // The default image path is broken when using Browserify - it searches the script tags on the page
 L.Icon.Default.imagePath = "https://unpkg.com/leaflet@1.0.1/dist/images/";
 
-module.exports = L.Wrld;
+export default Wrld;

--- a/src/wrld.js
+++ b/src/wrld.js
@@ -21,120 +21,117 @@ import * as indoorMapFloorOutlines from "./public/indoorMapFloorOutlines/indoorM
 
 import "./private/polyfills.js";
 
-var _baseUrl = "https://cdn-webgl.wrld3d.com/eegeojs/public/latest/";
-var _appName = "eeGeoWebGL.jgz";
-
+const _baseUrl = "https://cdn-webgl.wrld3d.com/eegeojs/public/latest/";
+const _appName = "eeGeoWebGL.jgz";
 
 var _mapObjects = [];
 var _emscriptenStartedLoading = false;
 var _emscriptenFinishedLoading = false;
 var _mapsWaitingInitialization = [];
 
-var onEmscriptenLoaded = function() {
-	_emscriptenFinishedLoading = true;
-	_mapsWaitingInitialization.forEach(function(module) {
-		window.createWrldModule(module);
-	});
-	_mapsWaitingInitialization = [];
+const onEmscriptenLoaded = () => {
+  _emscriptenFinishedLoading = true;
+  _mapsWaitingInitialization.forEach((module) => {
+    window.createWrldModule(module);
+  });
+  _mapsWaitingInitialization = [];
 };
 
-var createEmscriptenModule = function() {
-	if (!_emscriptenStartedLoading) {
-		var script = document.createElement("script");
-		script.src = _baseUrl + _appName;
-		script.onload = onEmscriptenLoaded;
-		document.body.appendChild(script);
-		_emscriptenStartedLoading = true;
-	}
+const createEmscriptenModule = () => {
+  if (!_emscriptenStartedLoading) {
+    var script = document.createElement("script");
+    script.src = _baseUrl + _appName;
+    script.onload = onEmscriptenLoaded;
+    document.body.appendChild(script);
+    _emscriptenStartedLoading = true;
+  }
 
-	var Module = {};
-	Module["locateFile"] = function(url) {
-		var absUrl = _baseUrl + url;
-		return absUrl;
-	};
-	Module["onExit"] = function(exitCode) {
-		if (exitCode === 1) {
-			var message = "Error: wrld.js failed to initialize";
-			if (!Module.ctx) {
-				message = "Error: WebGL unavailable in this browser";
-			}
-			_mapObjects.forEach(function(map) {
-				map.onError(message);
-			});
-		}
-	};
-  	return Module;
+  var Module = {};
+  Module["locateFile"] = (url) => {
+    var absUrl = _baseUrl + url;
+    return absUrl;
+  };
+  Module["onExit"] = (exitCode) => {
+    if (exitCode === 1) {
+      var message = "Error: wrld.js failed to initialize";
+      if (!Module.ctx) {
+        message = "Error: WebGL unavailable in this browser";
+      }
+      _mapObjects.forEach((map) => {
+        map.onError(message);
+      });
+    }
+  };
+  return Module;
 };
 
-var initializeMap = function(module) {
-	if (!_emscriptenFinishedLoading) {
-		_mapsWaitingInitialization.push(module);
-	}
-	else {
-		window.createWrldModule(module);
-	}
+const initializeMap = (module) => {
+  if (!_emscriptenFinishedLoading) {
+    _mapsWaitingInitialization.push(module);
+  }
+  else {
+    window.createWrldModule(module);
+  }
 };
 
-var findMapContainerElement = function(elementOrId) {
-	var element = elementOrId;
-	var id = null;
-	if (typeof elementOrId === "string") {
-		id = elementOrId;
-		element = document.getElementById(id);
-	}
-	if (element instanceof HTMLElement === false) {
-		var idError = (id === null) ? "" : (" with id '" + id + "'");
-		throw "No map container found" + idError;
-	}
-	return element;
+const findMapContainerElement = (elementOrId) => {
+  var element = elementOrId;
+  var id = null;
+  if (typeof elementOrId === "string") {
+    id = elementOrId;
+    element = document.getElementById(id);
+  }
+  if (element instanceof HTMLElement === false) {
+    var idError = (id === null) ? "" : (" with id '" + id + "'");
+    throw "No map container found" + idError;
+  }
+  return element;
 };
 
-var Wrld = {
-	map: function(domElement, apiKey, options) {
+const Wrld = {
+  map: (domElement, apiKey, options) => {
 
-		var wrldModule = createEmscriptenModule();
+    var wrldModule = createEmscriptenModule();
 
-		domElement = findMapContainerElement(domElement);
+    domElement = findMapContainerElement(domElement);
 
-		var browserDocument = document;
-		var browserWindow = window;
-		var mapId = _mapObjects.length;
-		var mapApiObject = new EmscriptenApi(wrldModule);
-		var mapOptions = options || {};
-		var onMapRemove = function() {
-			_mapObjects[mapId] = null;
-		};
-		var map = new EegeoMapController(mapId, mapApiObject, domElement, apiKey, browserWindow, browserDocument, wrldModule, mapOptions, onMapRemove);
-		_mapObjects.push(map);
+    var browserDocument = document;
+    var browserWindow = window;
+    var mapId = _mapObjects.length;
+    var mapApiObject = new EmscriptenApi(wrldModule);
+    var mapOptions = options || {};
+    var onMapRemove = () => {
+      _mapObjects[mapId] = null;
+    };
+    var map = new EegeoMapController(mapId, mapApiObject, domElement, apiKey, browserWindow, browserDocument, wrldModule, mapOptions, onMapRemove);
+    _mapObjects.push(map);
 
-		initializeMap(wrldModule);
+    initializeMap(wrldModule);
 
-		return map.leafletMap;
-	},
+    return map.leafletMap;
+  },
 
-	Marker: marker.Marker,
-	marker: marker.marker,
-	Popup: popup.Popup,
-	popup: popup.popup,
-	Polygon: polygon.Polygon,
-	polygon: polygon.polygon,
-	Polyline: polyline.Polyline,
-	polyline: polyline.polyline,
-	Prop: prop.Prop,
-	prop: prop.prop,
-	Heatmap: heatmap.Heatmap,
-	heatmap: heatmap.heatmap,
+  Marker: marker.Marker,
+  marker: marker.marker,
+  Popup: popup.Popup,
+  popup: popup.popup,
+  Polygon: polygon.Polygon,
+  polygon: polygon.polygon,
+  Polyline: polyline.Polyline,
+  polyline: polyline.polyline,
+  Prop: prop.Prop,
+  prop: prop.prop,
+  Heatmap: heatmap.Heatmap,
+  heatmap: heatmap.heatmap,
 
-	indoors: indoors,
-	space: space,
-	themes: themes,
-	buildings: buildings,
-	indoorMapEntities: indoorMapEntities,
-	indoorMapFloorOutlines: indoorMapFloorOutlines,
+  indoors: indoors,
+  space: space,
+  themes: themes,
+  buildings: buildings,
+  indoorMapEntities: indoorMapEntities,
+  indoorMapFloorOutlines: indoorMapFloorOutlines,
 
-	getMapById: function(mapId) {
-		return _mapObjects[mapId];
-	}
+  getMapById: (mapId) => _mapObjects[mapId]
 };
 
 L.popup = popup.popup;


### PR DESCRIPTION
# Summary
- Replace commonjs `require` with `import/export`  statements
- Build bundles using `microbundle`
- Tweak tests to work with the new import configuration

Now the CDN bundled version of `wrld.js` is always minified, and the `wrld.min.js` version was dropped. 