### PR TITLE
Bundle external dependencies (leaflet)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "microbundle --generateTypes false --name WRLD",
+    "build": "microbundle --generateTypes false --name WRLD --external none",
     "build-dist": "npm run build",
     "build-min": "npm run build",
     "watch": "microbundle watch",


### PR DESCRIPTION
See https://github.com/developit/microbundle/wiki/How-Microbundle-decides-which-dependencies-to-bundle

When was wrld.js is imported from the CDN, it was not required to also import leaflet. This meanst that it used to bundle leaflet as a dependency.

Passing --external none to microbundle should keep the same behavior as before