### PR TITLE
Fix `setView` regression

### DIFF
--- a/src/public/map.ts
+++ b/src/public/map.ts
@@ -313,7 +313,7 @@ export const Map: typeof MapType = L.Map.extend({
       }
     }
 
-    const _options = { center, zoom, ...options };
+    const _options = { ...options, zoom, location: center };
     this._cameraModule.setView(_options);
     return this;
   },


### PR DESCRIPTION
During the TypeScriptification of Wrld.map I confused the `location` property with `center`, causing `setView` not to move the camera.

Fixed by passing the correctly named option to `_cameraModule.setView`.