### PR TITLE
Configure build for unpkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wrld.js",
-  "version": "1.0.0-next.1",
+  "version": "1.0.0-next.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wrld.js",
   "amdName": "Wrld",
-  "version": "1.0.0-next.1",
+  "version": "1.0.0-next.3",
   "description": "A JavaScript API for beautiful 3D maps",
   "author": "WRLD",
   "license": "See license in LICENSE.md",
@@ -10,19 +10,20 @@
   "exports": "./dist/wrld.modern.js",
   "main": "./dist/wrld.cjs",
   "module": "./dist/wrld.module.js",
-  "unpkg": "./dist/wrld.js",
+  "unpkg": "./cdn/wrld.js",
   "types": "./dist/wrld.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/wrld3d/wrld.js.git"
   },
   "files": [
-    "dist"
+    "dist",
+    "cdn/wrld.js"
   ],
   "scripts": {
     "clean": "rm -rf dist cdn",
     "build:package": "microbundle",
-    "build:cdn": "microbundle -o cdn/wrld.js --format umd --generateTypes false --external none --define CDN_MODE=true",
+    "build:cdn": "microbundle -o cdn/wrld.js --format umd --generateTypes false --sourcemap false --external none",
     "build": "run-s build:package build:cdn",
     "build-dist": "npm run build",
     "build-min": "npm run build",


### PR DESCRIPTION
- Include standalone build cdn/wrld.js in package
- Point `unpkg` bundle to the standalone build
- Do not generate source maps for the standalone build