### PR TITLE
Improve build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ You can also use the command `npm run watch` to build continuously, watching fil
 
 Before executing automated tests, make sure you have eeGeoWebGL.js downloaded in `/tmp/sdk`. This can be achieved by running `./download-sdk.sh`.
 
-- `npm run test` will execute unit test, integration tests, and lint the project.
-- `npm run test:unit` will only execute unit and integration tests.
+- `npm run test` will execute automated tests and lint the project.
+- `npm run test:unit` will only execute automated tests.
 - `npm run test:watch` will watch the source files and execute affected tests.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ You can also use the command `npm run watch` to build continuously, watching fil
 
 ### Testing
 
-- `npm run test` will make a complete sanity check of the project, executing unit test, integration tests, linting and a full build.
+Before executing automated tests, make sure you have eeGeoWebGL.js downloaded in `/tmp/sdk`. This can be achieved by running `./download-sdk.sh`.
+
+- `npm run test` will execute unit test, integration tests, and lint the project.
 - `npm run test:unit` will only execute unit and integration tests.
 - `npm run test:watch` will watch the source files and execute affected tests.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can easily embed a 3D map in any web page. The code below shows a simple exa
 <!DOCTYPE HTML>
 <html>
   <head>
-    <script src="https://cdn-webgl.wrld3d.com/wrldjs/dist/latest/wrld.js"></script>
+    <script src="https://unpkg.com/wrld.js@1.x.x"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.1/leaflet.css" rel="stylesheet" />
   </head>
   <body>

--- a/download-sdk.sh
+++ b/download-sdk.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Trap errors #
 error() {
@@ -15,7 +15,7 @@ error() {
   # Exit with original error code #
   exit "${code}"
 }
-trap 'error ${LINENO}' ERR
+trap "error ${LINENO}" ERR
 
 sdk_version=$1
 
@@ -46,6 +46,3 @@ else
   echo "Downloading uncompressed memory file."
   curl ${memory_initialiser_url} 2>/dev/null >${sdk_dir}/eeGeoWebGL.js.mem
 fi
-
-npm install
-npm run test:interop

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <html>
   <head>
-    <script src="https://cdn-webgl.wrld3d.com/wrldjs/dist/v1.0.0/wrld.js"></script>
+    <script src="https://unpkg.com/wrld.js@1.x.x"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.1/leaflet.css" rel="stylesheet" />
 
     <link href="https://cdn-webgl.wrld3d.com/wrldjs/addons/resources/latest/css/wrld.css" rel="stylesheet"/>

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
     "watch": "microbundle watch --generateTypes false",
     "dev": "npm run watch",
     "lint": "eslint . --ext .js,.ts",
-    "test": "run-s test:unit test:lint test:build",
-    "test:build": "run-s build",
-    "test:lint": "run-s lint",
+    "test": "run-s lint test:unit",
     "test:interop": "jest -t map_interop --coverage=false",
     "test:unit": "jest",
     "test:watch": "jest --watch --coverage=false"

--- a/src/public/map_factory.ts
+++ b/src/public/map_factory.ts
@@ -9,7 +9,8 @@ import "../types/window"; // defines the overrides for the window global
  * It relies on unscoped variables to store various states, maybe this could be converted to a class/object instead?
  */
 
-const _baseUrl = "https://cdn-webgl.wrld3d.com/eegeojs/public/latest/";
+const _eeGeoWebGLVersion = "public/latest";
+const _baseUrl = `https://cdn-webgl.wrld3d.com/eegeojs/${_eeGeoWebGLVersion}/`;
 const _appName = "eeGeoWebGL.jgz";
 
 const _mapObjects: EegeoMapController[] = [];
@@ -28,7 +29,7 @@ const onEmscriptenLoaded = () => {
 const createEmscriptenModule = () => {
   if (!_emscriptenStartedLoading) {
     const script = document.createElement("script");
-    script.src = _baseUrl + _appName;
+    script.src = `${_baseUrl}${_appName}`;
     script.onload = onEmscriptenLoaded;
     document.body.appendChild(script);
     _emscriptenStartedLoading = true;
@@ -36,7 +37,7 @@ const createEmscriptenModule = () => {
 
   const Module: Module = {} as Module;
   Module.locateFile = (url) => {
-    const absUrl = _baseUrl + url;
+    const absUrl = `${_baseUrl}${url}`;
     return absUrl;
   };
   Module.onExit = (exitCode) => {


### PR DESCRIPTION
- Modify `test.sh` to only download eeGeoWebGL, and rename it to `download-sdk.sh`. This helps avoiding doubled CI installation steps.
- Change `npm run test` so that it does not peform a build. This helps avoiding doubled builds on CI.
- Factor out sdk cdn version to simplify grepping in CI.