### PR TITLE
Ignore .bk files in any directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ dist/
 cdn/
 node_modules/
 npm-debug.log
-src/*.bk
+*.bk
 src/*.tmp
 tmp/
 coverage/


### PR DESCRIPTION
Necessary to bring back the bleeding edge builds.