### PR TITLE
Don't boot up C++ module if the map's already been removed

### DIFF
--- a/src/public/map_factory.ts
+++ b/src/public/map_factory.ts
@@ -63,6 +63,10 @@ const initializeMap = (module: Module) => {
   }
 };
 
+const abortInitializingMap = (module: Module) => {
+  _mapsWaitingInitialization = _mapsWaitingInitialization.filter(item => item !== module);
+}
+
 const findMapContainerElement = (elementOrId: string | HTMLElement): HTMLElement => {
   if (elementOrId instanceof HTMLElement) {
     return elementOrId;
@@ -87,7 +91,10 @@ export const map = (domElement: HTMLElement | string, apiKey: string, options?: 
   const mapId = _mapObjects.length;
   const mapApiObject = new EmscriptenApi(wrldModule);
   const mapOptions = options || {};
-  const onMapRemove = () => { delete _mapObjects[mapId]; };
+  const onMapRemove = () => {
+    delete _mapObjects[mapId];
+    abortInitializingMap(wrldModule);
+  };
   const map = new EegeoMapController(mapId, mapApiObject, domElement, apiKey, browserWindow, browserDocument, wrldModule, mapOptions, onMapRemove);
   _mapObjects.push(map);
 


### PR DESCRIPTION
This is particularly useful if the map's used in a React component that uses a fresh map each time it's mounted, as in dev builds when using `StrictMode`, it'll unmount and remount all components, and so so quickly enough that `eeGeoWebGL.jgz` won't have downloaded yet.