### PR TITLE
Ensure Wrld.native.polygon doesn't become totally transparent when being removed and re-added

### DIFF
--- a/src/public/native/polygon.ts
+++ b/src/public/native/polygon.ts
@@ -73,6 +73,7 @@ export class Polygon {
     }
     this._map = map;
     map._polygonModule.addPolygon(this);
+    this.__colorNeedsChanged = true;
     return this;
   };
 


### PR DESCRIPTION
The colour gets set during a separate call in the update loop. When the JS object is constructed, the `__colorNeedsChanged` field is set, so the first time it's added, the next update loop iteration passes it into the platform. When it's removed and added again, the field was not being set again, so the platform was never receiving the colour for the new C++ object, and defaulting to zero for all channels, making it totally transparent.

We just need to ensure the field is set again when adding the polygon, and everything works.