### PR TITLE
Explicitly throw exception when using native polygon with L.Map

### DIFF
--- a/src/public/native/polygon.ts
+++ b/src/public/native/polygon.ts
@@ -28,6 +28,7 @@ declare class PolygonType extends L.Layer
   getPoints(): L.LatLng[];
   onAdd(map: Map): this;
   onRemove(): this;
+  beforeAdd(map: L.Map): this;
   protected _getConfig(): PolygonOptions;
   protected _colorNeedsChanged(): boolean;
   protected _onColorChanged(): void;
@@ -101,6 +102,13 @@ export const Polygon: typeof PolygonType = L.Layer.extend({
     if (this._wrldMap !== null) {
       this._wrldMap._polygonModule.removePolygon(this);
       this._wrldMap = null;
+    }
+    return this;
+  },
+
+  beforeAdd: function(this: PolygonType, map: L.Map) : PolygonType {
+    if (!(map instanceof Map)) {
+      throw new Error("Wrld.native.Polygon can only be used with Wrld.Map");
     }
     return this;
   },


### PR DESCRIPTION
The unit tests expected it to be thrown immediately, but with the change to make native polygons into Leaflet layers, it doesn't get added to the map until later, deferring throwing the exception until then.

If we throw it explicitly in the beforeAdd function, which is called synchronously, the tests pass, and also it's a little clearer where a mistake happened as the stack trace will make more sense.