### PR TITLE
Allocate a buffer big enough to hold a morton key

### DIFF
--- a/src/private/emscripten_api/emscripten_spaces_api.js
+++ b/src/private/emscripten_api/emscripten_spaces_api.js
@@ -69,12 +69,12 @@ export function EmscriptenSpacesApi(eegeoApiPointer, cwrap, emscriptenModule, em
     };
 
     var _getMortonKeyAtLatLng = (lat, long) => {
-        _getMortonKeyAtLatLngWrap = _getMortonKeyAtLatLngWrap || cwrap("getMortonKeyAtLatLng", null, ["number", "number", "number"]);
-        var mortonKey = "";
-        _emscriptenMemory.passString(mortonKey, (resultString) => {
-            _getMortonKeyAtLatLngWrap(lat, long, resultString);
-            mortonKey = _emscriptenMemory.stringifyPointer(resultString);
-        });
+        _getMortonKeyAtLatLngWrap = _getMortonKeyAtLatLngWrap || cwrap("getMortonKeyAtLatLng", "number", ["number", "number", "number"]);
+        var bufferSize = _getMortonKeyAtLatLngWrap(lat, long, 0);
+        var resultString = emscriptenMemory.createInt8Buffer(bufferSize).ptr;
+        _getMortonKeyAtLatLngWrap(lat, long, resultString);
+        var mortonKey = _emscriptenMemory.stringifyPointer(resultString);
+        emscriptenMemory.freeBuffer(resultString);
         return mortonKey;
     };
 


### PR DESCRIPTION
Previously we allocated a buffer big enough to hold an empty string, which is obviously smaller.
That would lead to it being overrun and horrible memory corruption happening.

Requires https://github.com/wrld3d/eegeo-mobile/pull/136