### PR TITLE
Handle touch events better

### DIFF
--- a/src/private/html_map_container.js
+++ b/src/private/html_map_container.js
@@ -60,7 +60,7 @@ export function HTMLMapContainer (browserDocument, browserWindow, parentElement,
             "width": "100%",
             "height": "100%",
             "background": "transparent",
-            "pointer-events": "none"
+            "touch-action": "none"
         };
         return _createDOMElement(parentElement, "div", attributes, style);
     };

--- a/src/public/map_type.ts
+++ b/src/public/map_type.ts
@@ -163,6 +163,7 @@ export declare class Map extends L.Map {
   /** @internal **/ _projectLatlngs: (layer: Layer, latlngs: L.LatLng[], result: unknown, projectedBounds: L.LatLngBounds[]) => boolean;
   // private methods
   protected _handleDOMEvent: L.DomEvent.EventHandlerFn;
+  protected _handleTouchStartEvent: L.DomEvent.EventHandlerFn;
   protected _onResize: L.DomEvent.EventHandlerFn;
   protected _onMoveEnd: L.LeafletEventHandlerFn;
   protected _getAngleFromCameraToHorizon: () => number;


### PR DESCRIPTION
* Don't use `"pointer-events": "none"` so we actually get touch events.
* Use `"touch-action": "none"` so the browser doesn't eat drags too long to be considered a click.
* Disable Leaflet's tap handling like we do for similar components.
* Stop propagation for touches that start on markers like we do for mouse events, allowing markers to be dragged without dragging the map along for the ride.

Required (along with an eegeo-mobile change) to fix #162