### PR TITLE
Forward events to where they historically went

### DIFF
--- a/src/public/map.ts
+++ b/src/public/map.ts
@@ -144,12 +144,6 @@ export const Map: typeof MapType = L.Map.extend({
     // @event keypress: KeyboardEvent
     // Fired when the user presses a key from the keyboard while the map is focused.
     L.DomEvent[onOff](
-      surface,
-      "click dblclick mousedown mouseup " + "mouseover mouseout mousemove contextmenu keypress",
-      this._handleDOMEvent,
-      this
-    );
-    L.DomEvent[onOff](
       this._container,
       "click dblclick mousedown mouseup " + "mouseover mouseout mousemove contextmenu keypress",
       this._handleDOMEvent,
@@ -158,10 +152,8 @@ export const Map: typeof MapType = L.Map.extend({
 
     // use HTML event API as Leaflet translates touch events to pointer events, which aren't what eegeo-mobile is listening for
     if (remove) {
-      surface.removeEventListener("touchstart", this._handleTouchStartEvent);
       this._container.removeEventListener("touchstart", this._handleTouchStartEvent);
     } else {
-      surface.addEventListener("touchstart", this._handleTouchStartEvent);
       this._container.addEventListener("touchstart", this._handleTouchStartEvent);
     }
 


### PR DESCRIPTION
cda49916d8efb4a6efb0d023e2cbc1cc844c8073 removed pointer-events: none from the map overlay, allowing Leaflet to see touch events it would otherwise have been unaware of, allowing things like the polygon editor to work properly.

This required some tweaking to how we registered our own handlers as events no longer reached the canvas underneath the overlay. Unfortunately, wrld.js itself isn't the only thing that needs that. Our WebGL example app also listens to events the old way, and it's fairly likely that at least one customer app does so, too.

For backwards compatibility, we forward events to the element that used to receive them. This is more hassle than ideal as a clone of the event must be used (you can't redispatch an  event in JS) and cloning is more complicated than it should be. Also, we've got to jump through hoops to prevent Leaflet's global pointer listeners being confused by a duplicate pointer.

Finally, the old handlers we set up so Leaflet could receive events that went past the overlay into the canvas are removed. It now gets all of them via the handlers on the overlay, so the canvas ones would only pick up the duplicate forwarded events, which is asking for trouble.